### PR TITLE
promicro_sx1262: Set battery adc voltage devider to 2:1, 3.6V ref

### DIFF
--- a/zephcore/boards/nrf52840/promicro_sx1262/promicro_sx1262.dts
+++ b/zephcore/boards/nrf52840/promicro_sx1262/promicro_sx1262.dts
@@ -75,10 +75,10 @@
 		};
 	};
 
-	/* Battery ADC: P0.31 (AIN7), 1M+1.5M voltage divider (5:3) */
+	/* Battery ADC: P0.31 (AIN7), 2:1 voltage devider, 3.6V ref */
 	zephyr,user {
 		io-channels = <&adc 7>;
-		vbat-mv-multiplier = <6000>;
+		vbat-mv-multiplier = <7200>;
 	};
 };
 


### PR DESCRIPTION
Tested on a Faketec board (promicro and sx1262). They all seem to be using symmetric 2:1 voltage dividers. 

e.g. https://github.com/user-attachments/files/23609361/schematics_V6_revB.pdf
