### PR TITLE
fix(heltec_v3): add ADC channel@0 node to fix -ENOTSUP on battery reads

### DIFF
--- a/zephcore/boards/esp32/heltec_wifi_lora32_v3/board.overlay
+++ b/zephcore/boards/esp32/heltec_wifi_lora32_v3/board.overlay
@@ -16,6 +16,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/adc/adc.h>
 
 / {
 	chosen {
@@ -72,6 +73,24 @@
 		input-codes = <INPUT_KEY_A>;
 		tap-codes = <INPUT_KEY_1 INPUT_KEY_B INPUT_KEY_D INPUT_KEY_C>;
 		tap-delay-ms = <400>;
+	};
+};
+
+/* Battery ADC channel configuration — required by espressif,esp32-adc driver.
+ * Without this child node, ADC_DT_SPEC_GET yields a zero-initialised
+ * channel_cfg where reference=ADC_REF_VDD_1, which the driver rejects
+ * with -ENOTSUP (-134).  ADC_GAIN_1_4 → ADC_ATTEN_DB_12 matches
+ * Arduino's default 11 dB attenuation (used to derive the 5.42x multiplier). */
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1_4";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };
 


### PR DESCRIPTION
## Summary

- `ADC_DT_SPEC_GET` resolves channel config from a `channel@N` child node of the ADC controller. Without it, `channel_cfg` is zero-initialised, setting `reference = ADC_REF_VDD_1` (enum value 0).
- The `espressif,esp32-adc` driver rejects any reference other than `ADC_REF_INTERNAL` with `-ENOTSUP` (-134), causing the repeated `ADC channel setup failed: -134` log errors on every battery read attempt.
- Fix: add `channel@0` under `&adc1` with `ADC_GAIN_1_4` (→ `ADC_ATTEN_DB_12`, ~3.1 V full-scale input), `ADC_REF_INTERNAL`, and 12-bit resolution. `ADC_GAIN_1_4` matches Arduino ESP32's default 11 dB attenuation from which the existing `5.42×` empirical battery multiplier was derived.

## Test plan

- [ ] Build for `heltec_wifi_lora32_v3/esp32s3/procpu` — no errors or warnings
- [ ] Flash and confirm `ADC channel setup failed: -134` no longer appears in serial output
- [ ] Confirm battery voltage readings look sane (~3.5–4.2 V for a charged LiPo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)