### PR TITLE
Fix red led polarity and update ThinkNode M1 target to match datasheet

### DIFF
--- a/zephcore/boards/nrf52840/thinknode_m1/board.conf
+++ b/zephcore/boards/nrf52840/thinknode_m1/board.conf
@@ -6,7 +6,7 @@
 # - GPS module on UART0, MX25R1635F 2MB QSPI flash
 # - Battery ADC on AIN2 (P0.04), 150K+150K divider
 # - Buzzer on P0.06, two buttons, GPS hardware switch
-# - LEDs: GREEN=P1.04, BLUE=P0.14
+# - LEDs: RED=P1.04, BLUE=P0.13
 
 # Board identification (matches Arduino MeshCore variant name)
 CONFIG_ZEPHCORE_BOARD_NAME="ThinkNode M1"

--- a/zephcore/boards/nrf52840/thinknode_m1/thinknode_m1-pinctrl.dtsi
+++ b/zephcore/boards/nrf52840/thinknode_m1/thinknode_m1-pinctrl.dtsi
@@ -7,8 +7,7 @@
  * Pin mappings (from Arduino MeshCore variant.h):
  *
  * SPI2 (LoRa SX1262):  SCK=P0.19, MISO=P0.23, MOSI=P0.22, CS=P0.24
- * SPI3 (EPD SSD1681):  SCK=P0.31, MISO=P1.06, MOSI=P0.29
- *                       (MISO shared with LED_RED — unused by write-only EPD)
+ * SPI3 (EPD SSD1681):  SCK=P0.31, MISO=NC, MOSI=P0.29
  * I2C0 (RTC/sensors):  SDA=P0.26, SCL=P0.27
  * UART0 (GPS 9600):    TX=P1.08 (→GPS RX), RX=P1.09 (←GPS TX)
  * PWM0 (buzzer):       P0.06
@@ -71,13 +70,12 @@
 	};
 
 	/* SPI3 for E-Paper display SSD1681
-	 * MISO on P1.06 is shared with LED_RED — e-ink is write-only so
-	 * MISO is never driven, but nRF SPIM requires all three pins. */
+	 * Display MISO is not connected on ThinkNode M1. */
 	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK,  0, 31)>,   /* P0.31 */
 				<NRF_PSEL(SPIM_MOSI, 0, 29)>,  /* P0.29 */
-				<NRF_PSEL(SPIM_MISO, 1, 6)>;   /* P1.06 (shared LED_RED) */
+				<NRF_PSEL_DISCONNECTED(SPIM_MISO)>;
 		};
 	};
 
@@ -85,7 +83,7 @@
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK,  0, 31)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 29)>,
-				<NRF_PSEL(SPIM_MISO, 1, 6)>;
+				<NRF_PSEL_DISCONNECTED(SPIM_MISO)>;
 			low-power-enable;
 		};
 	};

--- a/zephcore/boards/nrf52840/thinknode_m1/thinknode_m1.dts
+++ b/zephcore/boards/nrf52840/thinknode_m1/thinknode_m1.dts
@@ -12,12 +12,11 @@
  * - GPS module on UART0 (9600 baud, multi-constellation)
  * - 1200 mAh battery with ADC on AIN2 (150K+150K divider)
  * - Buzzer on PWM0, user button (P1.10), page button (P1.07), GPS hardware switch
- * - LEDs: GREEN=P1.04, BLUE=P0.14 (RED=P1.06 shared with display SPI)
+ * - LEDs: RED=P1.04, BLUE=P0.13
  *
- * Pin conflicts (shared by hardware design):
- * - P1.06: LED_RED + display SPI MISO (EPD is write-only, MISO unused)
- * - P1.05: LoRa power enable + GPS reset (shared power rail)
- * - P1.04: LED_GREEN + GPS PPS (GPS PPS blinks the green LED)
+ * Not connected on this target:
+ * - Display SPI MISO
+ * - GPS PPS
  */
 
 /dts-v1/;
@@ -43,54 +42,45 @@
 
 	aliases {
 		lora0 = &lora;
-		led0 = &led_green;
+		led0 = &led_red;
 		led1 = &led_blue;
-		led2 = &lora_tx_led;
-		lora-tx-led = &lora_tx_led;
+		lora-tx-led = &led_blue;
 		sw0 = &user_button;
 		watchdog0 = &wdt0;
 		buzzer = &buzzer;
 		gps-enable = &gps_enable_pin;
 	};
 
-	/* ---- LEDs (active-low) ---- */
+	/* ---- LEDs (active-high, matches MeshCore LED_STATE_ON=HIGH) ---- */
 	leds {
 		compatible = "gpio-leds";
 
-		led_green: led_0 {
-			gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;
-			label = "Green LED";
+		led_red: led_0 {
+			gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;
+			label = "Red LED";
 		};
 
 		led_blue: led_1 {
-			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
 			label = "Blue LED";
 		};
-
-		/* LoRa TX activity LED (active-high, matches Arduino P_LORA_TX_LED) */
-		lora_tx_led: led_2 {
-			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
-			label = "TX LED";
-		};
-		/* LED_RED (P1.06) omitted — shared with display SPI MISO */
 	};
 
 	/* ---- Buttons ---- */
 	buttons: buttons {
 		compatible = "gpio-keys";
 
-		/* Action / enter button (P1.10) — KEY_ENTER direct, no filter.
+		/* Action / enter button (P1.07) — KEY_ENTER direct, no filter.
 		 * action_page_enter() handles double-press confirmation internally. */
 		user_button: button_0 {
-			gpios = <&gpio1 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio1 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_ENTER>;
 			label = "User Button";
 		};
 
-		/* Page turn button (P1.07) — raw KEY_0, consumed by multi-tap below.
-		 * (P1.07 is shared with SPI1 MISO — safe because EPD is write-only.) */
+		/* Page turn button (P1.10) — raw KEY_0, consumed by multi-tap below. */
 		page_button: button_1 {
-			gpios = <&gpio1 7 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			gpios = <&gpio1 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			zephyr,code = <INPUT_KEY_0>;
 			label = "Page Button";
 		};


### PR DESCRIPTION
 - only two leds, red and blue
 - fix pin definition and polarity for leds
 - remove unmapped pins
 - swap buttons, so they match datasheet and marking on buttons

Datasheet: https://www.elecrow.com/download/product/CIL12901M/ThinkNode%20M1_LoRa_Meshtastic_Transceiver_DataSheet.pdf
This corresponds to my pull request to the MeshCore project: https://github.com/meshcore-dev/MeshCore/pull/2105