### PR TITLE
fix(rak4631): dont touch sx1262 power-enable pin

### DIFF
--- a/zephcore/boards/nrf52840/rak4631/board.overlay
+++ b/zephcore/boards/nrf52840/rak4631/board.overlay
@@ -102,6 +102,23 @@
 &lora {
        dio1-gpios = <&gpio1 15 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
        rx-boosted;
+
+       /* Upstream DTS labels P1.05 as rx-enable-gpios (per-direction
+        * antenna control), but on RAK4631 this pin is the SX1262 module
+        * power-enable (HIGH = on; see MeshCore variants/rak4631). The
+        * driver toggles per-direction GPIOs each TX/RX, which would
+        * pulse this pin LOW during RX. Stop the driver from touching it
+        * by deleting the property; the gpio-hog below pins it HIGH. */
+       /delete-property/ rx-enable-gpios;
+};
+
+&gpio1 {
+       sx1262_power_en {
+               gpio-hog;
+               gpios = <5 GPIO_ACTIVE_HIGH>;
+               output-high;
+               line-name = "sx1262-power-en";
+       };
 };
 
 /* LEDs are active-high on this board (stock RAK4631 DTS used active-low). */


### PR DESCRIPTION
Upstream Zephyr DTS
[rak4631_nrf52840.dts:124](https://github.com/zephyrproject-rtos/zephyr/blob/c6f781a4988fbb5cc3420f74e36add5ef65dbb94/boards/rakwireless/rak4631/rak4631_nrf52840.dts#L124) declares P1.05 as `rx-enable-gpios = <&gpio1 5 GPIO_ACTIVE_LOW>`. MeshCore treats the same pin as `SX126X_POWER_EN` ([variants/rak4631/variant.h:155](https://github.com/meshcore-dev/MeshCore/blob/1a7b3614a8439894714a58af55ab7f501e6bb928/variants/rak4631/variant.h#L155)) and only ever drives it HIGH (= module on, [RAK4631Board.cpp:51](https://github.com/meshcore-dev/MeshCore/blob/1a7b3614a8439894714a58af55ab7f501e6bb928/variants/rak4631/RAK4631Board.cpp#L51)). Our driver toggles it per direction at [sx126x.c:474-475](https://github.com/zephyrproject-rtos/zephyr/blob/684c9e8f32e4373a21098559f748f06915f950c9/drivers/lora/native/sx126x/sx126x.c#L474-L475) — RX state sets it electrically LOW.

This resulted in degraded rx performance.