### PR TITLE
Fix Heltec T114 screen long press

### DIFF
--- a/zephcore/CMakeLists.txt
+++ b/zephcore/CMakeLists.txt
@@ -335,14 +335,16 @@ endif()
 
 # Auto-pair: for each .conf in EXTRA_CONF_FILE, if a same-named .overlay exists
 # next to it, include it automatically (e.g. no_display.conf → no_display.overlay).
+# Relative paths are resolved against CMAKE_CURRENT_SOURCE_DIR (the app source dir).
 if(EXTRA_CONF_FILE)
     foreach(_conf IN LISTS EXTRA_CONF_FILE)
-        string(REPLACE ".conf" ".overlay" _paired_overlay "${_conf}")
-        if(EXISTS "${_paired_overlay}")
+        get_filename_component(_abs_conf "${_conf}" ABSOLUTE BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+        string(REPLACE ".conf" ".overlay" _abs_overlay "${_abs_conf}")
+        if(EXISTS "${_abs_overlay}")
             if(EXTRA_DTC_OVERLAY_FILE)
-                set(EXTRA_DTC_OVERLAY_FILE "${EXTRA_DTC_OVERLAY_FILE};${_paired_overlay}" CACHE STRING "" FORCE)
+                set(EXTRA_DTC_OVERLAY_FILE "${EXTRA_DTC_OVERLAY_FILE};${_abs_overlay}" CACHE STRING "" FORCE)
             else()
-                set(EXTRA_DTC_OVERLAY_FILE "${_paired_overlay}" CACHE STRING "" FORCE)
+                set(EXTRA_DTC_OVERLAY_FILE "${_abs_overlay}" CACHE STRING "" FORCE)
             endif()
         endif()
     endforeach()

--- a/zephcore/CMakeLists.txt
+++ b/zephcore/CMakeLists.txt
@@ -333,6 +333,21 @@ if(ZEPHCORE_BOARD_OVERLAY AND EXISTS ${ZEPHCORE_BOARD_OVERLAY})
     endif()
 endif()
 
+# Auto-pair: for each .conf in EXTRA_CONF_FILE, if a same-named .overlay exists
+# next to it, include it automatically (e.g. no_display.conf → no_display.overlay).
+if(EXTRA_CONF_FILE)
+    foreach(_conf IN LISTS EXTRA_CONF_FILE)
+        string(REPLACE ".conf" ".overlay" _paired_overlay "${_conf}")
+        if(EXISTS "${_paired_overlay}")
+            if(EXTRA_DTC_OVERLAY_FILE)
+                set(EXTRA_DTC_OVERLAY_FILE "${EXTRA_DTC_OVERLAY_FILE};${_paired_overlay}" CACHE STRING "" FORCE)
+            else()
+                set(EXTRA_DTC_OVERLAY_FILE "${_paired_overlay}" CACHE STRING "" FORCE)
+            endif()
+        endif()
+    endforeach()
+endif()
+
 # Debug: Show what configs are being used
 message(STATUS "ZephCore config hierarchy:")
 message(STATUS "  Common: ${ZEPHCORE_COMMON_CONF}")

--- a/zephcore/boards/nrf52840/heltec_t114/board.conf
+++ b/zephcore/boards/nrf52840/heltec_t114/board.conf
@@ -29,3 +29,7 @@ CONFIG_HEAP_MEM_POOL_SIZE=6144
 # 1.14" 240×135 TFT - the default 6×8 font is illegible at this pixel density.
 # Switch to the smallest Zephyr built-in CFB font >= 16 px tall (typically 10×16).
 CONFIG_ZEPHCORE_DISPLAY_LARGE_FONT=y
+
+# Long-press emits KEY_ENTER (1000ms hold), so two confirms + release gap
+# do not fit in the default 500ms window. Like T-Echo / ThinkNode M1.
+CONFIG_ZEPHCORE_UI_CONFIRM_WINDOW_MS=3000

--- a/zephcore/boards/nrf52840/heltec_t114/heltec_t114_nrf52840.dts
+++ b/zephcore/boards/nrf52840/heltec_t114/heltec_t114_nrf52840.dts
@@ -45,7 +45,7 @@
 	};
 
 	/* Input filter: user button long-press detection (1000ms) */
-	user_btn_longpress {
+	user_btn_longpress: user_btn_longpress {
 		compatible = "zephyr,input-longpress";
 		input = <&buttons>;
 		input-codes = <INPUT_KEY_0>;

--- a/zephcore/boards/nrf52840/heltec_t114/heltec_t114_nrf52840.dts
+++ b/zephcore/boards/nrf52840/heltec_t114/heltec_t114_nrf52840.dts
@@ -50,7 +50,7 @@
 		input = <&buttons>;
 		input-codes = <INPUT_KEY_0>;
 		short-codes = <INPUT_KEY_A>;
-		long-codes = <INPUT_KEY_POWER>;
+		long-codes = <INPUT_KEY_ENTER>;
 		long-delay-ms = <1000>;
 	};
 

--- a/zephcore/boards/nrf52840/heltec_t114/no_display.conf
+++ b/zephcore/boards/nrf52840/heltec_t114/no_display.conf
@@ -3,6 +3,9 @@
 # Pass via -DEXTRA_CONF_FILE when building for units without the TFT module.
 # TFT panel VDD (P0.03) stays off for the entire session.
 #
+# no_display.overlay (long-press => deep sleep) is auto-included by CMakeLists.txt
+# whenever this file is in EXTRA_CONF_FILE their is no need to pass it separately.
+#
 # west build -b heltec_t114 zephcore --pristine -- \
 #   -DEXTRA_CONF_FILE="boards/common/prod.conf;boards/nrf52840/heltec_t114/no_display.conf"
 

--- a/zephcore/boards/nrf52840/heltec_t114/no_display.overlay
+++ b/zephcore/boards/nrf52840/heltec_t114/no_display.overlay
@@ -1,0 +1,11 @@
+/*
+ * Heltec T114 - screenless build overlay
+ *
+ * Restores long-press => KEY_POWER (deep sleep) for headless units.
+ * The display variant uses KEY_ENTER (action_page_enter)
+ * Without a display there are no pages to enter, so KEY_POWER is more useful.
+ */
+
+&user_btn_longpress {
+	long-codes = <INPUT_KEY_POWER>;
+};


### PR DESCRIPTION
Because long-press behavior differs between the screen and screenless variants, this change was required to ensure long press works correctly on the screen-enabled version without affecting sleep mode behavior on the screenless variant.