### PR TITLE
fix: disable LBT phase-2 optimisation for loramac-node sx127x backend

### DIFF
--- a/zephcore/adapters/radio/LoRaRadioBase.cpp
+++ b/zephcore/adapters/radio/LoRaRadioBase.cpp
@@ -511,10 +511,11 @@ bool LoRaRadioBase::startSendRaw(const uint8_t *bytes, int len)
 	 * isReceiving() returns false during the CAD window because _tx_active
 	 * is set above — no extra gating needed.
 	 *
-	 * cad.mode = LBT is set unconditionally in buildModemConfig() today;
-	 * the `lbt` flag is a placeholder for any future Kconfig that toggles
-	 * the behaviour. */
-	const bool lbt = true;
+	 * The loramac-node sx127x backend uses a plain modem_acquire/release
+	 * mutex — there is no phase-2 path.  lora_config() returns -EBUSY if
+	 * called while async RX holds the mutex, so we must always cancel RX
+	 * first.  Disable the LBT optimisation for that backend. */
+	const bool lbt = !_loramac_node;
 
 	if (!lbt) {
 		atomic_set(&_in_recv_mode, 0);


### PR DESCRIPTION
The T-Beam v1.x is still a useful device in the MeshCore ecosystem and a ZephCore build is viable with some supporting PRs.

This is one such PR.

The loramac-node sx127x backend holds a modem mutex for the full duration of async RX. lora_config() returns -EBUSY if called while that mutex is held, so the phase-2 path (skip hwCancelReceive, let send_async handle RX→TX transition) leaves the mutex permanently locked and silently drops all TX.

Disable LBT for backends that set _loramac_node = true so RX is always cancelled before attempting to configure for TX.

Note:

_loramac_node is a bool member of LoRaRadioBase, which is the shared base class for all radio adapters. It defaults to false in the base constructor (line 33). Only one radio adapter overrides it:

// SX127xRadio.cpp — constructor
_loramac_node = true;

Every other adapter — SX126xRadio, LR1110Radio, LR2021Radio — never touches it, so they all stay
false.