### PR TITLE
T1000E: blink LED on shutdown when buzzer is muted

### DIFF
--- a/zephcore/helpers/ui-button/ui_task.c
+++ b/zephcore/helpers/ui-button/ui_task.c
@@ -503,6 +503,12 @@ static void action_deep_sleep(void)
 		k_sleep(K_MSEC(50));
 	}
 	buzzer_stop();
+
+#ifdef CONFIG_BOARD_T1000_E
+	if (buzzer_is_quiet()) {
+		ui_led_flash_shutdown();
+	}
+#endif
 #endif
 
 	/* Shared peripheral teardown + SENSE config for sw0 wake.

--- a/zephcore/helpers/ui/ui_common.c
+++ b/zephcore/helpers/ui/ui_common.c
@@ -212,6 +212,24 @@ void ui_led_flash_msg(void)
 #endif
 }
 
+/* Flash the heartbeat LED 3 times on shutdown.
+ * Used as a visual power-off indicator when the buzzer is muted. */
+void ui_led_flash_shutdown(void)
+{
+#if HAS_HEARTBEAT_LED
+	if (gpio_is_ready_dt(&s_heartbeat_led)) {
+		for (int i = 0; i < 3; i++) {
+			gpio_pin_set_dt(&s_heartbeat_led, 1);
+			k_sleep(K_MSEC(100));
+			gpio_pin_set_dt(&s_heartbeat_led, 0);
+			if (i < 2) {
+				k_sleep(K_MSEC(100));
+			}
+		}
+	}
+#endif
+}
+
 /* ========== Battery refresh ==========
  * Lazy: render path calls ui_refresh_battery(); ADC only fires when the
  * cached reading is older than UI_BATT_REFRESH_MS. Telemetry / stats paths

--- a/zephcore/helpers/ui/ui_task.h
+++ b/zephcore/helpers/ui/ui_task.h
@@ -165,6 +165,18 @@ void ui_set_leds_disabled(bool disabled);
 void ui_set_heartbeat_led(bool enabled);
 
 /**
+ * Flash the heartbeat LED immediately on message receipt.
+ * Cancels the current cycle, pulses, then resumes normal heartbeat.
+ */
+void ui_led_flash_msg(void);
+
+/**
+ * Flash the heartbeat LED 3 times as a visual shutdown indicator.
+ * Used when the buzzer is muted — gives visual feedback on power-off.
+ */
+void ui_led_flash_shutdown(void);
+
+/**
  * Set offgrid mode (client repeat) state for display page.
  */
 void ui_set_offgrid_mode(bool enabled);


### PR DESCRIPTION
Add a visual power-off indicator for t1000_e: when the buzzer is muted, the heartbeat LED flashes 3 times on long-press shutdown. The behavior is gated behind CONFIG_BOARD_T1000_E so only t1000_e is affected. Auto-shutdown paths are unaffected.