### PR TITLE
Fix Heltec V4 display not working

### DIFF
--- a/zephcore/adapters/radio/radio_common.h
+++ b/zephcore/adapters/radio/radio_common.h
@@ -24,7 +24,7 @@
 #define RX_RING_SIZE 8  /* ~2 KB; buffers burst arrivals at SF7/BW500 */
 
 /* --- TX wait thread --- */
-#define TX_WAIT_THREAD_STACK_SIZE 1024
+#define TX_WAIT_THREAD_STACK_SIZE 2048
 #define TX_WAIT_THREAD_PRIORITY   10     /* preemptible, below main thread */
 #define TX_TIMEOUT_MS             5000   /* hard timeout for TX completion signal */
 

--- a/zephcore/boards/esp32/heltec_wifi_lora32_v4/heltec_wifi_lora32_v4_procpu.dts
+++ b/zephcore/boards/esp32/heltec_wifi_lora32_v4/heltec_wifi_lora32_v4_procpu.dts
@@ -8,7 +8,7 @@
  *   OLED:   SSD1306 128x64 on I2C0
  *   Button: GPIO0
  *   LED:    GPIO35 (PWM via LEDC0)
- *   Vext:   GPIO36 active-HIGH (powers OLED and sensors)
+ *   Vext:   GPIO36 active-LOW PMOS rail switch (powers OLED and sensors)
  *   BatADC: GPIO1 (ADC1 ch0), enable GPIO37 active-LOW
  *
  * V4.2 (this file) — GC1109 PA, TX_EN on GPIO46.
@@ -20,7 +20,7 @@
  *       GPIO7  = VFEM_Ctrl LDO power (active-HIGH, always-on)
  *       GPIO2  = GC1109 CSD (chip enable, active-HIGH)
  *       GPIO46 = GC1109 CPS (TX mode select, active-HIGH)
- *   - Vext control is active-HIGH    (was active-LOW on V3)
+ *   - Vext rail switch is active-LOW (PMOS; GPIO36 low = rail on)
  *   - DIO2 used as RF switch alongside external FEM TX control
  *
  * LoRa SPI2:  SCLK=9, MOSI=10, MISO=11, NSS=8
@@ -85,13 +85,16 @@
 		full-ohms = <(100000 + 390000)>;
 	};
 
-	/* Vext — powers OLED and external peripherals (active-HIGH on GPIO36).
-	 * regulator-fixed + SSD1306 vin-supply: powers rail at boot without relying on
-	 * power-domains (CONFIG_PM_DEVICE is disabled in prj.conf). */
+	/* Vext rail switch — PMOS, ACTIVE LOW (GPIO36 low = rail ON).
+	 * Powers the OLED (incl. its I2C pull-ups) and the expansion header.
+	 * Verified on hardware: GPIO36 driven high leaves the rail floating
+	 * (~1.6 V) and the OLED unpowered; driven low gives a clean 3.3 V.
+	 * regulator-boot-on + always-on: the rail comes up at regulator init,
+	 * well before the SSD1306 driver init. */
 	vext_enable: vext-enable {
 		compatible = "regulator-fixed";
 		regulator-name = "vext";
-		enable-gpios = <&gpio1 4 GPIO_ACTIVE_HIGH>;  /* GPIO36 = gpio1 pin 4 */
+		enable-gpios = <&gpio1 4 GPIO_ACTIVE_LOW>;  /* GPIO36 = gpio1 pin 4 */
 		regulator-boot-on;
 		regulator-always-on;
 	};


### PR DESCRIPTION
Two bugs on the Heltec V4, found while trying to get the display working:

- Vext polarity is inverted: the DTS drives GPIO36 HIGH to turn on the OLED rail, but it's a PMOS, it needs to go LOW. Result: the rail was floating around ~1.6V instead of 3.3V, so the OLED never powered up. Verified with a multimeter. The official firmware gets away with it by accident: its `RefCountedDigitalPin` initializes the pin LOW and nothing ever drives it HIGH on the OLED build, so the rail just happens to stay on.
- Stack overflow on Xtensa (ESP32): `TX_WAIT_THREAD_STACK_SIZE` was 1024 bytes, measured actual usage during a normal TX cycle is 1252 bytes, so it was undersized regardless of anything else. We didn't hit this crash until after applying the display fix above; before that the board booted fine every time. Once it hits, it's a silent total freeze: no logs, no shell. Confirmed with the ESP32-S3's built-in JTAG — CPU parked in the double-exception vector, thread `lora_tx_wait`. Bumped to 2048.


<img width="320" src="https://github.com/user-attachments/assets/e23679b6-5360-4264-9850-f73efedbc091" />
