### PR TITLE
fix(cli): persist 'set freq' across a later savePrefs()

### DIFF
--- a/zephcore/helpers/CommonCLI.cpp
+++ b/zephcore/helpers/CommonCLI.cpp
@@ -852,7 +852,11 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                 float old_freq = _prefs->freq;
                 _prefs->freq = f;
                 savePrefs();
-                _prefs->freq = old_freq;
+                /* Keep _prefs->freq = f in RAM so a later savePrefs() (from any
+                 * other "set" command before reboot) can't rewrite the old freq
+                 * back; freeze the running radio on the old freq until reboot,
+                 * mirroring the "set radio" handler above. */
+                _callbacks->freezeRadioParams(old_freq, _prefs->bw, _prefs->sf, _prefs->cr);
                 strcpy(reply, "OK - reboot to apply");
             } else {
                 strcpy(reply, "Error: range 150-2500 MHz");


### PR DESCRIPTION
## Summary

`set freq <mhz>` over the USB CLI accepts the new frequency and replies
`OK - reboot to apply`, but the change is silently lost after reboot if any
other `set` command runs before the reboot. `get freq` / `get radio` also
report the **old** frequency immediately after a successful `set freq`.

## Root cause

The `set freq` handler in `CommonCLI::handleCommand()`
(`zephcore/helpers/CommonCLI.cpp`):

```c
float old_freq = _prefs->freq;
_prefs->freq = f;
savePrefs();
_prefs->freq = old_freq;   // reverts RAM back to old
```

It persists the new freq, then reverts `_prefs->freq` to the old value in RAM
to keep the running radio on the old params until reboot. But `_prefs` is the
source of truth that every `savePrefs()` writes, so:

- `get freq` (which reads `_prefs->freq`) returns the old value right after a
  successful set — the CLI contradicts itself.
- The next `savePrefs()` from any other command (`set rxduty`, `set name`, …)
  rewrites the whole prefs struct with the reverted old freq, overwriting the
  persisted new value. After reboot the change is gone.

The sibling `set radio` handler already solves the identical
"persist new, keep the live radio on old until reboot" requirement correctly:
it keeps `_prefs` = new and freezes the running radio via `freezeRadioParams()`
(→ `setRadioOverride()`). Its own comment even warns about this exact hazard:
*"mutate _prefs and save so later savePrefs() calls … don't clobber the new
values with stale RAM."* `set freq` misses that pattern.

## Fix

Mirror `set radio`: keep `_prefs->freq = f` and freeze the running radio on the
old freq via `freezeRadioParams()` instead of reverting the pref.

```diff
-                _prefs->freq = old_freq;
+                _callbacks->freezeRadioParams(old_freq, _prefs->bw, _prefs->sf, _prefs->cr);
```

Semantics are unchanged (the freq still applies at reboot; the running radio
stays on the old freq until then), but `_prefs->freq` now correctly retains the
new value, so `get` reflects it and later saves can't clobber it.
`freezeRadioParams()` is already implemented for the Repeater and Room Server
roles; the `CommonCLI` base is a no-op default, so other roles are unaffected.

## Reproduce (before fix)

```
set radio 910.525,62.5,8,8   # known start
reboot
set freq 903.0               # -> OK - reboot to apply
get freq                     # BUG: 910.525 (old value)
set rxduty on                # any command that calls savePrefs()
reboot
get freq                     # BUG: 910.525 — the 903.0 was lost
```

## Verified (after fix)

Hardware: Seeed XIAO MG24 + Wio-SX1262, Repeater role, built from release
`v20260704.220543` + this patch.

```
set freq 903.0   -> OK - reboot to apply
get freq         -> 903.000          # retained immediately
set rxduty on    -> OK
reboot
get freq         -> 903.000          # survives the intervening save + reboot
get radio        -> 903.000,62.5,8,8
```
