### PR TITLE
identity: validate pub/prv coherence on load and self-heal

### DIFF
--- a/zephcore/adapters/datastore/ZephyrDataStore.cpp
+++ b/zephcore/adapters/datastore/ZephyrDataStore.cpp
@@ -535,7 +535,33 @@ bool ZephyrDataStore::loadMainIdentity(mesh::LocalIdentity &identity)
 	if (!openRead(MAIN_ID_FILE, buf, sizeof(buf), len) || len < PRV_KEY_SIZE + PUB_KEY_SIZE) {
 		return false;
 	}
-	return identity.readFrom(buf, len);
+	if (!identity.readFrom(buf, len)) {
+		return false;
+	}
+	/* The 96-byte layout stores prv and pub side by side and readFrom()
+	 * trusts both halves. A mismatched pair (partial write, stale or
+	 * foreign file content) otherwise survives every boot: the node then
+	 * advertises a pub_key whose private scalar it does not hold — its
+	 * adverts verify nowhere, inbound DMs can't decrypt, and
+	 * CMD_EXPORT_PRIVATE_KEY hands companion apps a key that contradicts
+	 * SELF_INFO (seen in the field on a ThinkNode M1: apps re-request the
+	 * export on every connect and warn the user in a loop). Self-heal in
+	 * favour of the private key — the only usable secret — and persist. */
+	if (!identity.hasConsistentKeyPair()) {
+		/* Degenerate private key (all-zero page, reserved-prefix pub,
+		 * broken ECDH) is corruption, not a repairable pair — report
+		 * load failure so the caller regenerates a fresh identity. */
+		if (!mesh::LocalIdentity::validatePrivateKey(buf)) {
+			LOG_ERR("main identity corrupt (invalid prv) - regenerating");
+			return false;
+		}
+		LOG_WRN("main identity pub/prv mismatch - re-deriving pub from prv");
+		identity.rederivePubKey();
+		if (!saveMainIdentity(identity)) {
+			LOG_ERR("failed to persist re-derived identity");
+		}
+	}
+	return true;
 }
 
 bool ZephyrDataStore::saveMainIdentity(const mesh::LocalIdentity &identity)

--- a/zephcore/app/RepeaterDataStore.cpp
+++ b/zephcore/app/RepeaterDataStore.cpp
@@ -70,6 +70,23 @@ bool RepeaterDataStore::loadIdentity(mesh::LocalIdentity& id) {
 
     if (n >= PRV_KEY_SIZE) {
         if (id.readFrom(buf, n)) {
+            /* The 96-byte layout carries a stored pub_key that readFrom()
+             * trusts blindly. Repair a mismatched pair (partial write, stale
+             * or foreign file content) in favour of the private key, exactly
+             * like ZephyrDataStore::loadMainIdentity does for the companion. */
+            if (!id.hasConsistentKeyPair()) {
+                /* Degenerate private key is corruption, not a repairable
+                 * pair — fail the load so the caller regenerates. */
+                if (!mesh::LocalIdentity::validatePrivateKey(buf)) {
+                    LOG_ERR("identity corrupt (invalid prv) - regenerating");
+                    return false;
+                }
+                LOG_WRN("identity pub/prv mismatch - re-deriving pub from prv");
+                id.rederivePubKey();
+                if (!saveIdentity(id)) {
+                    LOG_ERR("failed to persist re-derived identity");
+                }
+            }
             LOG_INF("Loaded identity from %s", path);
             return true;
         }

--- a/zephcore/include/mesh/Identity.h
+++ b/zephcore/include/mesh/Identity.h
@@ -63,6 +63,17 @@ public:
 
 	bool readFrom(const uint8_t *src, size_t len);
 	size_t writeTo(uint8_t *dest, size_t max_len) const;
+
+	/* True when pub_key == prv_key·B, i.e. the halves belong to the same
+	 * identity. A pair loaded from storage can violate this (partial write,
+	 * foreign layout, bit rot) — nothing else in the pipeline re-checks it,
+	 * and an inconsistent pair silently breaks advert signatures, inbound
+	 * DM decryption and CMD_EXPORT_PRIVATE_KEY. */
+	bool hasConsistentKeyPair() const;
+
+	/* Repair an inconsistent pair in favour of the private key (the only
+	 * usable secret): pub_key = prv_key·B. */
+	void rederivePubKey();
 };
 
 } /* namespace mesh */

--- a/zephcore/src/Identity.cpp
+++ b/zephcore/src/Identity.cpp
@@ -199,6 +199,18 @@ size_t LocalIdentity::writeTo(uint8_t *dest, size_t max_len) const
 	return PRV_KEY_SIZE + PUB_KEY_SIZE;
 }
 
+bool LocalIdentity::hasConsistentKeyPair() const
+{
+	uint8_t derived[PUB_KEY_SIZE];
+	crypto_eddsa_scalarbase(derived, prv_key);
+	return memcmp(derived, pub_key, PUB_KEY_SIZE) == 0;
+}
+
+void LocalIdentity::rederivePubKey()
+{
+	crypto_eddsa_scalarbase(pub_key, prv_key);
+}
+
 void LocalIdentity::sign(uint8_t *sig, const uint8_t *message, int msg_len) const
 {
 	signExpanded(sig, prv_key, pub_key, message, (size_t)msg_len);


### PR DESCRIPTION
## Field report

A KiekR iOS user switched an Elecrow ThinkNode M1 from a stock MeshCore 1.17.x
companion build to **ZephCore 1.17.1 companion** on 2026-08-18 (app share-logs
show DEVICE_INFO changing from `manufacturer="Elecrow ThinkNode-M1"`,
build `14 Aug 2026` to `manufacturer="ThinkNode M1"`, build `2026 Aug 14` —
the latter matching `CONFIG_ZEPHCORE_BOARD_NAME` and the CMake
`string(TIMESTAMP ... "%Y %b %d")` build stamp).

Since that switch the node has an **internally inconsistent identity**:

- `SELF_INFO` advertises pub `1a736160…`. The node also auto-named itself
  `1A736160`, i.e. the `%02X%02X%02X%02X` default-name stamp already saw this
  pub before the first logged BLE connect.
- The 64-byte key returned by `CMD_EXPORT_PRIVATE_KEY` derives (Ed25519
  `scalar·B` on bytes 0..31) to a **different, stable** pub key. Two
  independent app builds agree: the older KiekR build blindly adopted the
  exported key on every connect and consistently obtained `e7d33c6b…`, and the
  newer build's export-vs-SELF_INFO cross-check rejects it on every connect
  (`adopt SKIPPED: exported-key pubkey != device SELF_INFO pubkey`). The state
  survived at least 3 reboots ("Restarted: SOFTWARE" v-contact notices) and
  ~29 logged connects over ~8 hours.
- We verified the derivation math is implementation-independent: for the same
  expanded key, ZephCore's vendored Monocypher (`crypto_eddsa_scalarbase`) and
  curve25519-dalek (`Scalar::from_bytes_mod_order · basepoint`) produce the
  identical pub key.

User-visible effect: the companion app re-requests the key export on every BLE
reconnect and, since it cross-checks the export against SELF_INFO, warns the
user on every reconnect — that endless popup loop is how this was found. A
node in this state also signs with a scalar that does not match its advertised
pub key, so (per Ed25519/X25519 math) its adverts cannot verify at peers and
DMs encrypted to the advertised key cannot be decrypted.

## Root cause class

`LocalIdentity::readFrom(buf, 96)` (the prv||pub storage layout used by
`/lfs/_main.id`) trusts both halves blindly, and nothing downstream ever
re-checks them. However a mismatched pair gets persisted — partial write,
stale or foreign file content, bit rot — it then **survives every boot
silently**.

We could not reproduce how this particular device's pair got mixed: in 1.17.1
source, generation (`generateFirstBootIdentity` → `fromSeed`), the
`CMD_IMPORT_PRIVATE_KEY` handler, the CLI `set prv.key` path and both save
paths each produce coherent pairs (we host-tested the generation/derivation
core against the vendored Monocypher), and an all-`0xFF`/all-`0x00` (erased
flash) prv half does not derive the observed pub either. What turns a one-off
storage anomaly into a permanently broken node is the missing validation —
that is what this PR addresses.

## Fix

- `LocalIdentity::hasConsistentKeyPair()` — checks `pub_key == prv_key·B`.
- `LocalIdentity::rederivePubKey()` — repairs in favour of the private key
  (the only usable secret).
- Both identity load sites validate after a successful 96-byte load:
  - `ZephyrDataStore::loadMainIdentity` (companion)
  - `RepeaterDataStore::loadIdentity` (repeater + room server)

  On mismatch: if the private key fails `validatePrivateKey()` (degenerate
  scalar, reserved-prefix pub, broken ECDH) the load reports failure so the
  caller regenerates a fresh identity; otherwise the pub is re-derived from
  the private key, persisted, and a warning is logged.

Cost: one `crypto_eddsa_scalarbase` per boot (plus the validate only in the
mismatch path). No wire-format or API change. Intended effect for an affected
node: at the next boot its advertised identity becomes the prv-derived pub —
the key it has actually been signing with all along.

## Verification

- Host-compiled the patched `Identity.cpp` against the vendored Monocypher and
  exercised the new paths:

  ```
  fresh consistent=1
  mixed consistent=0
  repaired consistent=1 pub_matches_prv_owner=1
  zero_prv_valid=0
  mixed_prv_valid=1
  ```

  (fresh keypair passes; a blob with prv from identity A + pub from identity B
  is detected and repaired back to A's pub; an all-zero prv is rejected by
  `validatePrivateKey` so the load-site regenerates instead of "healing"
  garbage.)
- `west build -b thinknode_m1 zephcore --pristine` builds green for both the
  **companion** (FLASH 55.26%, RAM 87.39%, UF2 769536 B) and the
  **repeater.conf** variant (UF2 505856 B); `nm` confirms both new symbols
  (`hasConsistentKeyPair`, `rederivePubKey`) in each linked ELF, and the
  patched `Identity.cpp` / `ZephyrDataStore.cpp` / `RepeaterDataStore.cpp`
  object files are part of the builds.
- The repaired/regenerated flows were **not** exercised on hardware here;
  review of the two load-site changes appreciated.
