### PR TITLE
radio.fem.rxgain: software control of external FEM/LNA gain (T096, RAK3401, V4.3, WT2)

### DIFF
--- a/zephcore/Repeater_CLI_commands.md
+++ b/zephcore/Repeater_CLI_commands.md
@@ -247,6 +247,7 @@ All `set uplink.*` changes are saved immediately and only applied after reboot.
 | `get path.hash.mode` | Path hashing algorithm: `0`, `1`, or `2` |
 | `get loop.detect` | Loop detection level: `off`, `minimal`, `moderate`, or `strict` |
 | `get radio.rxgain` | RX gain boost: `0` or `1` |
+| `get radio.fem.rxgain` | External FEM LNA RX gain (boards with a controllable FEM only): `on` or `off` |
 | `get rxduty` | RX duty cycle mode: `0` or `1` |
 | `get gps duty` | Now-effective GPS duty interval in seconds (`always on (0)` when continuous) |
 | `get gps diag` | What the last GPS module-configuration attempt did — which path ran, bytes sent, and tracked satellites per constellation. See **GPS configuration diagnostics** in the GPS section for the field reference |
@@ -296,6 +297,7 @@ Changes are persisted immediately unless noted. Some require a reboot.
 | `set path.hash.mode <mode>` | 0, 1, or 2 | Path hashing algorithm |
 | `set loop.detect <mode>` | `off`, `minimal`, `moderate`, `strict` | Loop detection sensitivity |
 | `set radio.rxgain <0\|1\|on\|off>` | | RX gain boost, applied live. Replies `Error: unsupported` on radios without RX boost (SX127x); the pref is still saved. |
+| `set radio.fem.rxgain <0\|1\|on\|off>` | | External FEM LNA RX gain, applied live. No-op on boards without a controllable FEM; the pref is still saved. |
 | `set rxduty <0\|1\|on\|off>` | | RX duty cycle mode *(reboot required)*. Window timing auto-sized per SF/BW/preamble from the SX126x datasheet constraints (boot log line `rxduty:` shows the result). Zero-loss guarantee assumes senders on preamble-32 firmware (current MeshCore at SF≤8); legacy preamble-16 senders are only caught ~50% worst-phase — keep off until the local mesh has converted. Presets with 16-symbol preambles (SF≥9) fall back to continuous RX automatically. |
 | `set adc.multiplier <mult>` | (0 = use board default) | Battery voltage ADC calibration multiplier |
 | `set meshtimesync <on\|off>` | default **off** | Mesh time sync: automatically correct this node's clock from the consensus of Ed25519-signed advert timestamps heard on the mesh. Steps at most ±1 h per step, one step per 6 h; abstains without a quorum (default 6) of tenured agreeing senders; never overrides a clock set in the last 7 days, whether from GPS (re-armed on every fix) or a manual set. See `MESHTIMESYNC.md`. |

--- a/zephcore/adapters/board/ZephyrBoard.cpp
+++ b/zephcore/adapters/board/ZephyrBoard.cpp
@@ -61,6 +61,23 @@ static const struct device *vbat_enable_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL
 static const struct device *vbat_enable_dev = NULL;
 #endif
 
+/* External FEM/LNA enable, active-HIGH path (KCT8103L PA_CSD, SKY66122 CSD+CPS).
+ * Present on boards that expose a `lora_fem_en` regulator-fixed nodelabel. */
+#if DT_NODE_EXISTS(DT_NODELABEL(lora_fem_en))
+static const struct device *lora_fem_en_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(lora_fem_en));
+#else
+static const struct device *lora_fem_en_dev = NULL;
+#endif
+
+/* External FEM/LNA enable, active-LOW path (KCT8103L PA_CTX on boards where CTX
+ * doubles as the LNA bypass select: HIGH = TX/bypass, LOW = LNA active in RX).
+ * Present on boards that expose a `lora_fem_ctx` regulator-fixed nodelabel. */
+#if DT_NODE_EXISTS(DT_NODELABEL(lora_fem_ctx))
+static const struct device *lora_fem_ctx_dev = DEVICE_DT_GET_OR_NULL(DT_NODELABEL(lora_fem_ctx));
+#else
+static const struct device *lora_fem_ctx_dev = NULL;
+#endif
+
 /*
  * Battery voltage multiplier - prefer devicetree, fallback to Kconfig
  * Formula: Battery_mV = (raw * VBAT_MV_MULTIPLIER) / 4096
@@ -255,6 +272,15 @@ void ZephyrBoard::onBeforeTransmit()
 		gpio_pin_set_dt(&tx_led, 1);
 	}
 #endif
+	/* TX always needs the PA path: CSD/CTX-as-enable boards go HIGH, CTX-as-LNA
+	 * -bypass boards (V4.3) also go HIGH here, which is what bypasses the LNA
+	 * for the transmit path. Independent of the fem_rxgain RX preference. */
+	if (lora_fem_en_dev) {
+		regulator_enable(lora_fem_en_dev);
+	}
+	if (lora_fem_ctx_dev) {
+		regulator_enable(lora_fem_ctx_dev);
+	}
 }
 
 void ZephyrBoard::onAfterTransmit()
@@ -262,6 +288,28 @@ void ZephyrBoard::onAfterTransmit()
 #if HAS_TX_LED
 	gpio_pin_set_dt(&tx_led, 0);
 #endif
+	/* Restore the RX-time FEM state now that TX is done. */
+	if (lora_fem_en_dev && !_fem_lna_enabled) {
+		regulator_disable(lora_fem_en_dev);
+	}
+	if (lora_fem_ctx_dev && _fem_lna_enabled) {
+		regulator_disable(lora_fem_ctx_dev);  /* CTX=LOW = LNA active */
+	}
+	/* fem_rxgain=0 on a CTX board: leave CTX HIGH (bypass), already set above. */
+}
+
+void ZephyrBoard::setFemLnaEnabled(bool enable)
+{
+	_fem_lna_enabled = enable;
+	if (lora_fem_en_dev) {
+		if (enable) regulator_enable(lora_fem_en_dev);
+		else        regulator_disable(lora_fem_en_dev);
+	}
+	if (lora_fem_ctx_dev) {
+		/* CTX is inverted relative to lora_fem_en: LOW = LNA active. */
+		if (enable) regulator_disable(lora_fem_ctx_dev);
+		else        regulator_enable(lora_fem_ctx_dev);
+	}
 }
 
 void ZephyrBoard::reboot()

--- a/zephcore/adapters/board/ZephyrBoard.h
+++ b/zephcore/adapters/board/ZephyrBoard.h
@@ -27,10 +27,19 @@ public:
 	uint8_t getStartupReason() const override;
 	bool isExternalPowered() override;  /* nRF52: VBUS present (USB/charger); else false */
 
+	/* External FEM/LNA control (KCT8103L, SKY66122...) — boards expose this via
+	 * a `lora_fem_en` or `lora_fem_ctx` devicetree nodelabel; boards without one
+	 * silently no-op. enable=true keeps the LNA path active during RX; the TX
+	 * path is always asserted in onBeforeTransmit() regardless of this setting. */
+	void setFemLnaEnabled(bool enable);
+
 private:
 	/* Runtime override for vbat-mv-multiplier. Units match DT `vbat-mv-multiplier`
 	 * (mV scale such that `mv = multiplier * raw / 4096`). 0 = use DT default. */
 	float _adc_multiplier_override = 0.0f;
+
+	/* FEM LNA state requested via radio.fem.rxgain; re-applied after every TX. */
+	bool _fem_lna_enabled = false;
 };
 
 } /* namespace mesh */

--- a/zephcore/app/RepeaterDataStore.cpp
+++ b/zephcore/app/RepeaterDataStore.cpp
@@ -219,6 +219,9 @@ bool RepeaterDataStore::loadPrefs(NodePrefs& prefs) {
     /* LR2021 side-detector SFs, offsets 301-303.  Absent in <304-byte files;
      * the no-op EOF read leaves the zeroed default = feature off. */
     fs_read(&file, prefs.extra_sf, sizeof(prefs.extra_sf));
+    /* External FEM/LNA gain, offset 304. Absent in <305-byte files; the no-op
+     * EOF read keeps the constructor default fem_rxgain=0 (off). */
+    fs_read(&file, &prefs.fem_rxgain, sizeof(prefs.fem_rxgain));
 
     fs_close(&file);
 
@@ -250,6 +253,7 @@ bool RepeaterDataStore::loadPrefs(NodePrefs& prefs) {
     if (prefs.path_hash_mode > 2) prefs.path_hash_mode = 0;
     if (prefs.loop_detect > LOOP_DETECT_STRICT) prefs.loop_detect = LOOP_DETECT_MINIMAL;
     if (prefs.rx_boost > 1) prefs.rx_boost = 0;
+    if (prefs.fem_rxgain > 1) prefs.fem_rxgain = 0;
     if (prefs.rx_duty_cycle > 1) prefs.rx_duty_cycle = 0;
     if (prefs.meshtimesync > 1) prefs.meshtimesync = 0;
     if (prefs.cad_auto > 1) prefs.cad_auto = 0;
@@ -368,6 +372,8 @@ bool RepeaterDataStore::savePrefs(const NodePrefs& prefs) {
     fs_write(&file, &prefs.cad_busycap, sizeof(prefs.cad_busycap));
     /* LR2021 side-detector SFs (offsets 301-303) */
     fs_write(&file, prefs.extra_sf, sizeof(prefs.extra_sf));
+    /* External FEM/LNA gain (offset 304) */
+    fs_write(&file, &prefs.fem_rxgain, sizeof(prefs.fem_rxgain));
 
     ret = fs_sync(&file);
     fs_close(&file);

--- a/zephcore/app/RepeaterMesh.cpp
+++ b/zephcore/app/RepeaterMesh.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "RepeaterMesh.h"
+#include <adapters/board/ZephyrBoard.h>
 #include <mesh/Utils.h>
 #include <helpers/AdvertDataHelpers.h>
 #include <helpers/TxtDataHelpers.h>
@@ -1232,6 +1233,10 @@ void RepeaterMesh::setTxPower(int8_t power_dbm) {
 
 bool RepeaterMesh::setRxBoostedGain(bool enable) {
     return getRadioDriver(_radio).setRxBoost(enable);
+}
+
+void RepeaterMesh::setFemRxGain(bool enable) {
+    static_cast<mesh::ZephyrBoard&>(_board).setFemLnaEnabled(enable);
 }
 
 bool RepeaterMesh::configSideDetectors(const uint8_t* sfs, uint8_t num) {

--- a/zephcore/app/RepeaterMesh.h
+++ b/zephcore/app/RepeaterMesh.h
@@ -258,6 +258,7 @@ public:
     void dumpLogFile() override;
     void setTxPower(int8_t power_dbm) override;
     bool setRxBoostedGain(bool enable) override;
+    void setFemRxGain(bool enable) override;
     bool configSideDetectors(const uint8_t* sfs, uint8_t num) override;
     void formatNeighborsReply(char* reply) override;
     void removeNeighbor(const uint8_t* pubkey, int key_len) override;

--- a/zephcore/boards/esp32/heltec_wifi_lora32_v43/board.overlay
+++ b/zephcore/boards/esp32/heltec_wifi_lora32_v43/board.overlay
@@ -70,11 +70,28 @@
 	status = "okay";
 };
 
-/* Patch LoRa radio: add pull-down on DIO1 and enable RX boosted mode.
- * DTS defines antenna-enable, tx-enable, dio2-tx-enable, and TCXO already. */
+/* KCT8103L CTX (GPIO5): ENABLED=HIGH=TX/LNA-bypass, DISABLED=LOW=LNA active.
+ * ZephyrBoard controls CTX via this nodelabel (radio.fem.rxgain), inverted
+ * relative to the CSD-style lora_fem_en used on heltec_t096/rak3401_1watt.
+ * tx-enable-gpios removed from the SX1262 node below to free GPIO5 from the
+ * native radio driver, which otherwise force-enables it on every RX/TX
+ * cycle regardless of the RX preference. */
+/ {
+	lora_fem_ctx: lora-fem-ctx {
+		compatible = "regulator-fixed";
+		regulator-name = "lora-fem-ctx";
+		enable-gpios = <&gpio0 5 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
+};
+
+/* Patch LoRa radio: add pull-down on DIO1, enable RX boosted mode, and free
+ * CTX (GPIO5) for the lora_fem_ctx node above. DTS defines antenna-enable,
+ * tx-enable, dio2-tx-enable, and TCXO already. */
 &lora0 {
 	dio1-gpios = <&gpio0 14 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;
 	rx-boosted;
+	/delete-property/ tx-enable-gpios;
 };
 
 /* I2C sensors — auto-detected at runtime */

--- a/zephcore/boards/esp32/heltec_wireless_tracker_v2/board.overlay
+++ b/zephcore/boards/esp32/heltec_wireless_tracker_v2/board.overlay
@@ -8,6 +8,7 @@
  */
 
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/gpio/espressif-esp32-gpio.h>
 
 / {
 	chosen {
@@ -43,6 +44,28 @@
 		tap-codes = <INPUT_KEY_1 INPUT_KEY_LEFT>;
 		tap-delay-ms = <400>;
 	};
+
+	/* KCT8103L PA_CSD (GPIO4): ENABLED=LNA active, DISABLED=LNA off in RX
+	 * (still forced on for TX by ZephyrBoard::onBeforeTransmit()).
+	 * ZephyrBoard controls PA_CSD via this nodelabel (radio.fem.rxgain),
+	 * same pattern already used by heltec_t096/rak3401_1watt for their own
+	 * CSD pin. antenna-enable-gpios removed from the SX1262 node below to
+	 * free GPIO4 from the native radio driver, which otherwise
+	 * force-enables it unconditionally on every RX/TX cycle.
+	 *
+	 * ESP32_GPIO_SLEEP_HOLD_EN kept from the property this replaces: light
+	 * sleep powers down RTC_PERIPH, and GPIO4 is an RTC-capable pad; without
+	 * the hold, the FEM would come out of sleep parked in an undefined state. */
+	lora_fem_en: lora-fem-en {
+		compatible = "regulator-fixed";
+		regulator-name = "lora-fem-en";
+		enable-gpios = <&gpio0 4 (GPIO_ACTIVE_HIGH | ESP32_GPIO_SLEEP_HOLD_EN)>;
+		regulator-boot-on;
+	};
+};
+
+&lora0 {
+	/delete-property/ antenna-enable-gpios;
 };
 
 /* I2C sensors — auto-detected at runtime. Header pins per MeshCore:

--- a/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840.dts
+++ b/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840.dts
@@ -121,6 +121,22 @@
 		startup-delay-us = <1000>;
 	};
 
+	/* KCT8103L PA_CSD (P0.12): active-HIGH FEM/LNA enable, controlled by
+	 * ZephyrBoard for radio.fem.rxgain (regulator-fixed, no regulator-boot-on
+	 * — the driver's own SX126x reset sequence covers the settle time, same
+	 * as this rail's vfem_enable above already documents). Separate from
+	 * vfem_enable (P0.30), which just powers the FEM rail and stays always
+	 * on; this is the gain-control pin. Distinct from antenna-enable-gpios
+	 * previously used here: that native SX126x driver property force-enables
+	 * the pin on every RX/TX cycle, giving no room for an RX-only preference.
+	 * PA_CTX (P1.09, tx-enable-gpios) and PA_CPS (dio2-tx-enable) on the lora0
+	 * node below are unrelated TX/RX switching, left untouched. */
+	lora_fem_en: lora-fem-en {
+		compatible = "regulator-fixed";
+		regulator-name = "lora-fem-en";
+		enable-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
+	};
+
 	/* Schematic net ADC_Ctrl: P1.15 enables the VBAT divider. */
 	vbat_enable: vbat-enable {
 		compatible = "regulator-fixed";
@@ -314,14 +330,16 @@
 
 		/*
 		 * KCT8103L PA/FEM control:
-		 * - PA_CSD P0.12 -> CSD, active-HIGH FEM enable.
+		 * - PA_CSD P0.12 -> CSD, active-HIGH FEM enable. Exposed as the
+		 *   lora_fem_en regulator node above (radio.fem.rxgain) instead of
+		 *   antenna-enable-gpios here, so ZephyrBoard can gate it in RX
+		 *   instead of the native driver forcing it on every RX/TX cycle.
 		 * - PA_CTX P1.09 -> CTX, HIGH for TX in the existing ZephCore
 		 *   SX1262 tx-enable model. MeshCore uses the same net for
 		 *   TX/LNA-bypass control.
 		 * - PA_CPS is not an MCU GPIO on T096; it is the SX1262 DIO2
 		 *   net into the KCT8103L CPS pin, so use dio2-tx-enable.
 		 */
-		antenna-enable-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>; /* PA_CSD */
 		tx-enable-gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;       /* PA_CTX */
 		dio2-tx-enable;                                      /* PA_CPS */
 

--- a/zephcore/boards/nrf52840/rak3401_1watt/rak3401_1watt.dts
+++ b/zephcore/boards/nrf52840/rak3401_1watt/rak3401_1watt.dts
@@ -86,22 +86,15 @@
 		regulator-boot-on;
 	};
 
-	/* SKY66122 FEM enable — must be HIGH before SX1262 can transmit.
-	 * SX126X_POWER_EN = P0.21 (IO3 on WisBlock base). */
-	lora_pwr_enable: lora-pwr-enable {
+	/* SKY66122 FEM enable — controlled by ZephyrBoard for radio.fem.rxgain.
+	 * CSD+CPS are tied together on RAK13302 PCB, routed to IO3 (P0.21).
+	 * HIGH = FEM active (LNA during RX, PA path available for TX).
+	 * No regulator-boot-on: ZephyrBoard drives this via onBeforeTransmit/
+	 * onAfterTransmit/setFemLnaEnabled, same as heltec_t096's lora_fem_en. */
+	lora_fem_en: lora-fem-en {
 		compatible = "regulator-fixed";
-		regulator-name = "lora-pwr-enable";
+		regulator-name = "lora-fem-en";
 		enable-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
-		regulator-boot-on;
-		/* Documents the FEM's requirement, but do not rely on it:
-		 * regulator-boot-on sends regulator_common_init() down the
-		 * refcount-only branch, so regulator_delay() never runs and this
-		 * value is inert. The real settle time comes from the SX126x driver's
-		 * own reset (5 ms NRESET pulse + 5 ms wait + BUSY poll) before any
-		 * SPI traffic, at LORA_INIT_PRIORITY 90 against this rail's 75.
-		 * Anything put behind this rail that does NOT reset-then-wait needs
-		 * zephyr,deferred-init instead; see meshtracker_x1's i2c0. */
-		startup-delay-us = <10000>;
 	};
 
 	/* ---- Battery ADC ---- */

--- a/zephcore/helpers/CommonCLI.cpp
+++ b/zephcore/helpers/CommonCLI.cpp
@@ -135,6 +135,7 @@ void CommonCLI::loadPrefs(const char* path) {
     ok = ok && prefs_read(&file, &_prefs->probe_interval, sizeof(_prefs->probe_interval)); // 299
     ok = ok && prefs_read(&file, &_prefs->cad_busycap, sizeof(_prefs->cad_busycap));            // 300
     ok = ok && prefs_read(&file, _prefs->extra_sf, sizeof(_prefs->extra_sf));                  // 301-303
+    ok = ok && prefs_read(&file, &_prefs->fem_rxgain, sizeof(_prefs->fem_rxgain));              // 304
 
     if (!ok) {
         LOG_WRN("Prefs file %s truncated, some fields use defaults", path);
@@ -179,6 +180,7 @@ void CommonCLI::loadPrefs(const char* path) {
     _prefs->gps_enabled = constrain(_prefs->gps_enabled, (uint8_t)0, (uint8_t)1);
     _prefs->advert_loc_policy = constrain(_prefs->advert_loc_policy, (uint8_t)0, (uint8_t)2);
     _prefs->rx_boost = constrain(_prefs->rx_boost, (uint8_t)0, (uint8_t)1);
+    _prefs->fem_rxgain = constrain(_prefs->fem_rxgain, (uint8_t)0, (uint8_t)1);
     _prefs->rx_duty_cycle = constrain(_prefs->rx_duty_cycle, (uint8_t)0, (uint8_t)1);
     _prefs->flood_max_unscoped = constrain(_prefs->flood_max_unscoped, (uint8_t)0, (uint8_t)64);
     _prefs->flood_max_advert = constrain(_prefs->flood_max_advert, (uint8_t)0, (uint8_t)64);
@@ -267,6 +269,7 @@ void CommonCLI::savePrefs(const char* path) {
     fs_write(&file, &_prefs->probe_interval, sizeof(_prefs->probe_interval));
     fs_write(&file, &_prefs->cad_busycap, sizeof(_prefs->cad_busycap));
     fs_write(&file, _prefs->extra_sf, sizeof(_prefs->extra_sf));
+    fs_write(&file, &_prefs->fem_rxgain, sizeof(_prefs->fem_rxgain));  // 304
 
     fs_close(&file);
     LOG_INF("Saved prefs to %s", path);
@@ -506,6 +509,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
             snprintf(reply, CLI_REPLY_SIZE, "> %.6f", _prefs->node_lat);
         } else if (memcmp(config, "lon", 3) == 0) {
             snprintf(reply, CLI_REPLY_SIZE, "> %.6f", _prefs->node_lon);
+        } else if (memcmp(config, "radio.fem.rxgain", 16) == 0) {
+            snprintf(reply, CLI_REPLY_SIZE, "> %s", _prefs->fem_rxgain ? "on" : "off");
         } else if (memcmp(config, "radio.rxgain", 12) == 0) {
             snprintf(reply, CLI_REPLY_SIZE, "> %d", (int)_prefs->rx_boost);
         } else if (memcmp(config, "radio", 5) == 0) {
@@ -1129,6 +1134,20 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                 }
             } else {
                 strcpy(reply, "Error: unsupported by this board");
+            }
+        } else if (memcmp(config, "radio.fem.rxgain ", 17) == 0) {
+            const char* arg = &config[17];
+            int val = -1;
+            if (memcmp(arg, "on", 2) == 0) val = 1;
+            else if (memcmp(arg, "off", 3) == 0) val = 0;
+            else if (arg[0] == '0' || arg[0] == '1') val = atoi(arg);
+            if (val == 0 || val == 1) {
+                _prefs->fem_rxgain = (uint8_t)val;
+                savePrefs();
+                _callbacks->setFemRxGain(val == 1);
+                snprintf(reply, CLI_REPLY_SIZE, "OK - radio.fem.rxgain=%s", _prefs->fem_rxgain ? "on" : "off");
+            } else {
+                strcpy(reply, "Error: must be 0, 1, on, or off");
             }
         } else if (memcmp(config, "radio.rxgain ", 13) == 0) {
             const char* arg = &config[13];

--- a/zephcore/helpers/CommonCLI.h
+++ b/zephcore/helpers/CommonCLI.h
@@ -46,6 +46,10 @@ public:
     /* Apply RX boosted gain live; returns false when the radio has no
      * RX boost feature (upstream PR #2844 semantics). */
     virtual bool setRxBoostedGain(bool enable) { (void)enable; return false; }
+    /* Toggle an external FEM/LNA (KCT8103L, SKY66122...) between an
+     * always-on TX path and RX-gated LNA. Boards without an external FEM
+     * simply ignore this. */
+    virtual void setFemRxGain(bool enable) { (void)enable; }
     /* Configure LR2021 side detectors (multi-SF receive); num = 0 disables.
      * Returns false when the radio has no side detectors, or when the set
      * violates a chip constraint — the driver is the validator. */

--- a/zephcore/helpers/NodePrefs.h
+++ b/zephcore/helpers/NodePrefs.h
@@ -93,6 +93,7 @@ struct NodePrefs {
 	float adc_multiplier;
 	char owner_info[120];
 	uint8_t rx_boost;               // 1 = boosted RX gain (+3dB), 0 = power save
+	uint8_t fem_rxgain;             // 1 = external FEM LNA active during RX, 0 = off (power save)
 	uint8_t rx_duty_cycle;          // 1 = RX duty cycle, 0 = continuous RX
 	/* RESERVED — formerly apc_enabled / apc_margin (Adaptive Power Control,
 	 * removed in 1.16.6). These two bytes are still read and written at their
@@ -191,6 +192,7 @@ static inline void initNodePrefs(NodePrefs* prefs) {
 	prefs->advert_loc_policy = ADVERT_LOC_NONE;
 	prefs->adc_multiplier = 0.0f;
 	prefs->rx_boost = 1;              // Default to boosted RX for better sensitivity
+	prefs->fem_rxgain = 0;            // Default OFF — external FEM LNA off, internal boost only
 	prefs->rx_duty_cycle = 0;         // Default OFF — continuous RX for best reliability
 	prefs->_reserved_apc_enabled = 0; // reserved (was APC), see NodePrefs
 	prefs->_reserved_apc_margin = 0;  // reserved (was APC), see NodePrefs

--- a/zephcore/src/main_companion.cpp
+++ b/zephcore/src/main_companion.cpp
@@ -732,6 +732,10 @@ public:
 		return lora_radio.setRxBoost(enable);
 	}
 
+	void setFemRxGain(bool enable) override {
+		zephyr_board.setFemLnaEnabled(enable);
+	}
+
 	bool configSideDetectors(const uint8_t* sfs, uint8_t num) override {
 		return lora_radio.configSideDetectors(sfs, num);
 	}
@@ -1573,6 +1577,7 @@ int main(void)
 
 	/* Apply RX boost and duty cycle from prefs */
 	lora_radio.setRxBoost(companion_mesh.prefs.rx_boost != 0);
+	zephyr_board.setFemLnaEnabled(companion_mesh.prefs.fem_rxgain != 0);
 	lora_radio.enableRxDutyCycle(companion_mesh.prefs.rx_duty_cycle != 0);
 	lora_radio.setCadParams(companion_mesh.prefs.cad_auto != 0,
 				companion_mesh.prefs.cad_offset,

--- a/zephcore/src/main_repeater.cpp
+++ b/zephcore/src/main_repeater.cpp
@@ -745,6 +745,7 @@ int main(void)
 
 	/* Apply RX boost and duty cycle from prefs */
 	lora_radio.setRxBoost(prefs->rx_boost != 0);
+	zephyr_board.setFemLnaEnabled(prefs->fem_rxgain != 0);
 	lora_radio.enableRxDutyCycle(prefs->rx_duty_cycle != 0);
 	lora_radio.setCadParams(prefs->cad_auto != 0, prefs->cad_offset,
 				prefs->probe_interval, prefs->cad_busycap);


### PR DESCRIPTION
## Summary

None of ZephCore's boards currently expose software control over their external FEM/LNA gain. On `master`, the FEM enable pin on every board that has one (T096, RAK3401, V4.3, WT2) is wired through a devicetree property that forces it permanently on (either `antenna-enable-gpios`/`tx-enable-gpios` on the native SX126x driver, or a plain `regulator-boot-on` regulator). There's no way to trade RX sensitivity for power draw, or to A/B the FEM's real effect on reception.

This PR adds that control end to end:

- a `radio.fem.rxgain` CLI command (`get`/`set`, same shape as the existing `radio.rxgain`)
- a persisted `NodePrefs::fem_rxgain` preference
- `ZephyrBoard::setFemLnaEnabled()`, which drives either a `lora_fem_en` node (active-HIGH CSD-style FEMs) or a `lora_fem_ctx` node (active-LOW CTX-as-bypass-select FEMs), whichever a board's devicetree defines. Both are `DT_NODE_EXISTS`-gated, so boards that define neither are unaffected.
- the devicetree change on each of the 4 boards to actually expose the pin under one of those nodelabels instead of the always-on driver property
- both the repeater and companion roles wired up

## Scope

This touches 4 boards and both roles, not a single-board bugfix. Flagging that up front since the CLI command itself is new (nothing to migrate, defaults to off).

## Test plan

- [x] Compiles clean on all 4 boards: `heltec_t096` (repeater), `rak3401_1watt` (repeater), `heltec_wifi_lora32_v43` (repeater, exercises the `lora_fem_ctx` path), `heltec_wireless_tracker_v2` (companion, exercises the `lora_fem_en` path plus the companion hook)
- [x] `heltec_wireless_tracker_v2`: confirmed on real hardware. CLI `get`/`set radio.fem.rxgain` round-trips correctly, and the FEM's real RF effect is now visible (noise floor swings ~23 dB between on/off, versus no observable effect before this change)
- [ ] Not yet flashed/tested on `heltec_t096`, `rak3401_1watt`, or `heltec_wifi_lora32_v43`. The devicetree-level fix is the same pattern already validated on WT2, but not bench-confirmed on these three.