### PR TITLE
build: enable USB CDC companion transport for ESP32-S3 boards

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -272,8 +272,25 @@ if [[ $1 == "esp32" ]]; then
 
         if [[ $2 == "companions" ]]; then
             # build ESP32 companions (production is the default)
+            #
+            # ESP32-S3 boards that include esp32s3_usb_otg.dtsi in their overlay
+            # get the USB CDC-ACM companion transport enabled via esp32s3_usb.conf.
+            # This gives the full companion protocol over native USB (Web Serial /
+            # app.meshcore.io) in addition to BLE.  Boards without the OTG DTSI
+            # (Heltec V3/CP2102, Wireless Tracker V1, C3/C6, classic ESP32) are
+            # unaffected — they use BLE or serial_companion instead.
+            usb_conf=""
+            if [[ $board =~ esp32s3 && $board =~ (heltec_wifi_lora32_v4|heltec_wireless_tracker_v2|xiao_esp32s3|lilygo_t3s3|station_g2) ]]; then
+                usb_conf="boards/common/esp32s3_usb.conf"
+            fi
+
             echo "Now building $board companion"
-            west build -b "$board" zephcore --pristine --sysbuild
+            if [[ -n "$usb_conf" ]]; then
+                echo "  USB CDC companion: enabled ($usb_conf)"
+                west build -b "$board" zephcore --pristine --sysbuild -- -DEXTRA_CONF_FILE="$usb_conf"
+            else
+                west build -b "$board" zephcore --pristine --sysbuild
+            fi
             FLASH_SIZE=$(
                 python3 -c '
 import re

--- a/build.sh
+++ b/build.sh
@@ -280,7 +280,9 @@ if [[ $1 == "esp32" ]]; then
             # (Heltec V3/CP2102, Wireless Tracker V1, C3/C6, classic ESP32) are
             # unaffected — they use BLE or serial_companion instead.
             usb_conf=""
-            if [[ $board =~ esp32s3 && $board =~ (heltec_wifi_lora32_v4|heltec_wireless_tracker_v2|xiao_esp32s3|lilygo_t3s3|station_g2) ]]; then
+            board_stem="${board%%/*}"
+            overlay="zephcore/boards/esp32/${board_stem}/board.overlay"
+            if [[ $board =~ esp32s3 && -f "$overlay" ]] && grep -q 'esp32s3_usb_otg\.dtsi' "$overlay"; then
                 usb_conf="boards/common/esp32s3_usb.conf"
             fi
 


### PR DESCRIPTION
ESP32-S3 boards that include `esp32s3_usb_otg.dtsi` in their overlay now get `boards/common/esp32s3_usb.conf` passed automatically during companion builds. This enables the full companion protocol over native USB (CDC-ACM), allowing Web Serial apps (`app.meshcore.io`) to control the device over USB in addition to BLE.

**Affected boards:** heltec_wifi_lora32_v4, heltec_wifi_lora32_v43, heltec_wireless_tracker_v2, xiao_esp32s3, lilygo_t3s3, station_g2.

Boards without the OTG DTSI (Heltec V3/CP2102, Wireless Tracker V1,C3/C6, classic ESP32) aren't affected.