### PR TITLE
leds: PWM brightness control, persisted, with TX/RX pin-share arbitration

### DIFF
--- a/zephcore/adapters/board/ZephyrBoard.cpp
+++ b/zephcore/adapters/board/ZephyrBoard.cpp
@@ -10,6 +10,7 @@
 #include <zephyr/sys/reboot.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -97,14 +98,34 @@
 #endif
 #endif
 
-/* LoRa radio activity LED (optional — defined per-board via DT alias).  Still
- * called tx_led after "set leds.radio" gave it an RX mode, because the DT alias
- * it comes from is named lora-tx-led on every board that has one. */
-#if DT_NODE_EXISTS(DT_ALIAS(lora_tx_led))
+/* LoRa radio activity LED (optional — defined per-board via DT alias). Still
+ * called tx_led after "set leds.radio" gave it an RX mode, because the DT
+ * alias it comes from is named lora-tx-led on every board that has one.
+ *
+ * PWM path (DT_ALIAS(lora_tx_pwm_led)) takes priority when it exists — used
+ * on boards where the TX LED is the same physical LED as the heartbeat
+ * (e.g. T096, see helpers/ui/ui_common.c), so both share the one brightness
+ * in helpers/led_gate.h instead of the plain GPIO path fighting over the
+ * pin. */
+#if DT_NODE_EXISTS(DT_ALIAS(lora_tx_pwm_led))
+static const struct pwm_dt_spec tx_led_pwm = PWM_DT_SPEC_GET(DT_ALIAS(lora_tx_pwm_led));
+#define HAS_TX_LED_PWM 1
+#define HAS_TX_LED 0
+static int tx_led_init(void)
+{
+	if (device_is_ready(tx_led_pwm.dev)) {
+		pwm_set_pulse_dt(&tx_led_pwm, 0);  /* start dark, same as GPIO_OUTPUT_INACTIVE */
+	}
+	return 0;
+}
+SYS_INIT(tx_led_init, APPLICATION, 90);
+#elif DT_NODE_EXISTS(DT_ALIAS(lora_tx_led))
 static const struct gpio_dt_spec tx_led =
 	GPIO_DT_SPEC_GET(DT_ALIAS(lora_tx_led), gpios);
+#define HAS_TX_LED_PWM 0
 #define HAS_TX_LED 1
 #else
+#define HAS_TX_LED_PWM 0
 #define HAS_TX_LED 0
 #endif
 
@@ -359,12 +380,24 @@ const char *ZephyrBoard::getManufacturerName() const
 
 void ZephyrBoard::onBeforeTransmit()
 {
-#if HAS_TX_LED
 	/* Honour the LED master gate ("set leds off") and then the activity mode
 	 * ("set leds.radio"). On a headless repeater this is the only LED that ever
 	 * lights, so both have to be checked here and not just in the UI layer.
 	 * onAfterTransmit() still clears the pin unconditionally, so a gate or mode
 	 * flipped mid-transmit can't strand it lit. */
+#if HAS_TX_LED_PWM
+	/* PWM-shared boards (T096) don't yet have the RX-pulse/pin-hold interlock
+	 * below -- that machinery (s_tx_lit/s_rx_pulse_off) is declared only under
+	 * HAS_TX_LED. Mode-gated brightness write only for now; see the rebase
+	 * notes for why this is a deliberate gap, not an oversight. */
+	uint8_t mode = zephcore_leds_radio_mode();
+	if (!zephcore_leds_disabled() &&
+	    (mode == LEDS_RADIO_TX || mode == LEDS_RADIO_ALL)) {
+		uint32_t pulse = (uint32_t)((uint64_t)tx_led_pwm.period *
+					     zephcore_led_brightness_pct() / 100);
+		pwm_set_pulse_dt(&tx_led_pwm, pulse);
+	}
+#elif HAS_TX_LED
 	uint8_t mode = zephcore_leds_radio_mode();
 	if (!zephcore_leds_disabled() &&
 	    (mode == LEDS_RADIO_TX || mode == LEDS_RADIO_ALL)) {
@@ -382,7 +415,9 @@ void ZephyrBoard::onBeforeTransmit()
 
 void ZephyrBoard::onAfterTransmit()
 {
-#if HAS_TX_LED
+#if HAS_TX_LED_PWM
+	pwm_set_pulse_dt(&tx_led_pwm, 0);
+#elif HAS_TX_LED
 	atomic_set(&s_tx_lit, 0);
 	gpio_pin_set_dt(&tx_led, 0);
 #if ZEPHCORE_LED_PIN_SHARED

--- a/zephcore/adapters/board/ZephyrBoard.cpp
+++ b/zephcore/adapters/board/ZephyrBoard.cpp
@@ -111,14 +111,8 @@
 static const struct pwm_dt_spec tx_led_pwm = PWM_DT_SPEC_GET(DT_ALIAS(lora_tx_pwm_led));
 #define HAS_TX_LED_PWM 1
 #define HAS_TX_LED 0
-static int tx_led_init(void)
-{
-	if (device_is_ready(tx_led_pwm.dev)) {
-		pwm_set_pulse_dt(&tx_led_pwm, 0);  /* start dark, same as GPIO_OUTPUT_INACTIVE */
-	}
-	return 0;
-}
-SYS_INIT(tx_led_init, APPLICATION, 90);
+/* Init deferred to the combined tx_led_init() below (with the GPIO path),
+ * since both now also need to arm s_rx_pulse_off -- see that block. */
 #elif DT_NODE_EXISTS(DT_ALIAS(lora_tx_led))
 static const struct gpio_dt_spec tx_led =
 	GPIO_DT_SPEC_GET(DT_ALIAS(lora_tx_led), gpios);
@@ -130,7 +124,8 @@ static const struct gpio_dt_spec tx_led =
 #endif
 
 /* True when this board wires the activity LED to the same pin as the heartbeat
- * (8 of the supported boards do).  Only those pay for the arbitration hold in
+ * (8 of the supported boards do, counting only the plain-GPIO ones -- see the
+ * PWM branch below for the rest).  Only those pay for the arbitration hold in
  * led_gate.c — everywhere else the two LEDs are independent and the calls
  * compile out.  led1 is checked as well because ui_common.c falls back to it
  * when a board has no led0. */
@@ -141,8 +136,34 @@ static const struct gpio_dt_spec tx_led =
       DT_NODE_EXISTS(DT_ALIAS(led1)) && \
       DT_SAME_NODE(DT_ALIAS(led1), DT_ALIAS(lora_tx_led))
 #define ZEPHCORE_LED_PIN_SHARED 1
+/* PWM equivalent: true when heartbeat and TX activity are aliased to the same
+ * PWM LED node (T096, Wireless Tracker V2). Not the case on every PWM board --
+ * RAK3401 has two independent PWM LEDs (green/blue), so this stays 0 there and
+ * the hold below is correctly never taken. */
+#elif HAS_TX_LED_PWM && DT_NODE_EXISTS(DT_ALIAS(heartbeat_pwm_led)) && \
+      DT_SAME_NODE(DT_ALIAS(heartbeat_pwm_led), DT_ALIAS(lora_tx_pwm_led))
+#define ZEPHCORE_LED_PIN_SHARED 1
 #else
 #define ZEPHCORE_LED_PIN_SHARED 0
+#endif
+
+/* PWM-or-GPIO write for the activity LED, mirroring heartbeat_led_write() in
+ * helpers/ui/ui_common.c -- same reasoning: the write itself must not care
+ * which path is compiled in, only the callers (onBeforeTransmit/
+ * onAfterTransmit/onPacketReceived/rx_pulse_off_handler below) do. */
+#if HAS_TX_LED_PWM
+static inline void tx_led_write(bool on)
+{
+	uint32_t pulse = on ? (uint32_t)((uint64_t)tx_led_pwm.period *
+					  zephcore_led_brightness_pct() / 100)
+			     : 0;
+	pwm_set_pulse_dt(&tx_led_pwm, pulse);
+}
+#elif HAS_TX_LED
+static inline void tx_led_write(bool on)
+{
+	gpio_pin_set_dt(&tx_led, on ? 1 : 0);
+}
 #endif
 
 #include <zephyr/logging/log.h>
@@ -194,8 +215,8 @@ static const struct device *const fuel_gauge_dev =
 #define HAS_FUEL_GAUGE 0
 #endif
 
-/* Initialize activity LED GPIO at boot */
-#if HAS_TX_LED
+/* Initialize activity LED (PWM or GPIO) at boot */
+#if HAS_TX_LED_PWM || HAS_TX_LED
 /* Width of the receive blink.  A transmit holds the LED for its whole airtime,
  * but a receive is a single edge — the packet is over by the time the driver
  * hands it up — so RX has to be a fixed one-shot.  30 ms is deliberately longer
@@ -208,7 +229,9 @@ static const struct device *const fuel_gauge_dev =
  * interlock that keeps an RX one-shot from clearing a pin that TX still owns:
  * the two are driven from different threads (radio TX path vs system work
  * queue), so without it a pulse landing mid-transmit would blank the LED for
- * the rest of the packet. */
+ * the rest of the packet. Applies equally to the PWM-shared boards (T096,
+ * Wireless Tracker V2): same race, same fix, just written through
+ * tx_led_write() instead of a bare gpio_pin_set_dt(). */
 static atomic_t s_tx_lit;
 static struct k_work_delayable s_rx_pulse_off;
 
@@ -220,7 +243,7 @@ static void rx_pulse_off_handler(struct k_work *work)
 	if (atomic_get(&s_tx_lit)) {
 		return;
 	}
-	gpio_pin_set_dt(&tx_led, 0);
+	tx_led_write(false);
 #if ZEPHCORE_LED_PIN_SHARED
 	zephcore_led_radio_hold_pin(false);
 #endif
@@ -228,9 +251,15 @@ static void rx_pulse_off_handler(struct k_work *work)
 
 static int tx_led_init(void)
 {
+#if HAS_TX_LED_PWM
+	if (device_is_ready(tx_led_pwm.dev)) {
+		pwm_set_pulse_dt(&tx_led_pwm, 0);  /* start dark, same as GPIO_OUTPUT_INACTIVE */
+	}
+#else
 	if (gpio_is_ready_dt(&tx_led)) {
 		gpio_pin_configure_dt(&tx_led, GPIO_OUTPUT_INACTIVE);
 	}
+#endif
 	k_work_init_delayable(&s_rx_pulse_off, rx_pulse_off_handler);
 	return 0;
 }
@@ -384,20 +413,10 @@ void ZephyrBoard::onBeforeTransmit()
 	 * ("set leds.radio"). On a headless repeater this is the only LED that ever
 	 * lights, so both have to be checked here and not just in the UI layer.
 	 * onAfterTransmit() still clears the pin unconditionally, so a gate or mode
-	 * flipped mid-transmit can't strand it lit. */
-#if HAS_TX_LED_PWM
-	/* PWM-shared boards (T096) don't yet have the RX-pulse/pin-hold interlock
-	 * below -- that machinery (s_tx_lit/s_rx_pulse_off) is declared only under
-	 * HAS_TX_LED. Mode-gated brightness write only for now; see the rebase
-	 * notes for why this is a deliberate gap, not an oversight. */
-	uint8_t mode = zephcore_leds_radio_mode();
-	if (!zephcore_leds_disabled() &&
-	    (mode == LEDS_RADIO_TX || mode == LEDS_RADIO_ALL)) {
-		uint32_t pulse = (uint32_t)((uint64_t)tx_led_pwm.period *
-					     zephcore_led_brightness_pct() / 100);
-		pwm_set_pulse_dt(&tx_led_pwm, pulse);
-	}
-#elif HAS_TX_LED
+	 * flipped mid-transmit can't strand it lit. Same interlock on PWM-shared
+	 * boards (T096, Wireless Tracker V2) as on plain-GPIO ones -- only the
+	 * final write (tx_led_write()) differs. */
+#if HAS_TX_LED_PWM || HAS_TX_LED
 	uint8_t mode = zephcore_leds_radio_mode();
 	if (!zephcore_leds_disabled() &&
 	    (mode == LEDS_RADIO_TX || mode == LEDS_RADIO_ALL)) {
@@ -408,18 +427,16 @@ void ZephyrBoard::onBeforeTransmit()
 #if ZEPHCORE_LED_PIN_SHARED
 		zephcore_led_radio_hold_pin(true);
 #endif
-		gpio_pin_set_dt(&tx_led, 1);
+		tx_led_write(true);
 	}
 #endif
 }
 
 void ZephyrBoard::onAfterTransmit()
 {
-#if HAS_TX_LED_PWM
-	pwm_set_pulse_dt(&tx_led_pwm, 0);
-#elif HAS_TX_LED
+#if HAS_TX_LED_PWM || HAS_TX_LED
 	atomic_set(&s_tx_lit, 0);
-	gpio_pin_set_dt(&tx_led, 0);
+	tx_led_write(false);
 #if ZEPHCORE_LED_PIN_SHARED
 	zephcore_led_radio_hold_pin(false);
 #endif
@@ -428,7 +445,7 @@ void ZephyrBoard::onAfterTransmit()
 
 void ZephyrBoard::onPacketReceived()
 {
-#if HAS_TX_LED
+#if HAS_TX_LED_PWM || HAS_TX_LED
 	uint8_t mode = zephcore_leds_radio_mode();
 	if (zephcore_leds_disabled() ||
 	    (mode != LEDS_RADIO_RX && mode != LEDS_RADIO_ALL)) {
@@ -444,7 +461,7 @@ void ZephyrBoard::onPacketReceived()
 #if ZEPHCORE_LED_PIN_SHARED
 	zephcore_led_radio_hold_pin(true);
 #endif
-	gpio_pin_set_dt(&tx_led, 1);
+	tx_led_write(true);
 	/* Reschedule rather than schedule: back-to-back packets should extend the
 	 * blink, not have the first one's handler cut the second one short. */
 	k_work_reschedule(&s_rx_pulse_off, K_MSEC(RX_PULSE_MS));

--- a/zephcore/adapters/datastore/ZephyrDataStore.cpp
+++ b/zephcore/adapters/datastore/ZephyrDataStore.cpp
@@ -907,6 +907,14 @@ void ZephyrDataStore::loadPrefs(NodePrefs &prefs)
 	if (off < len) {
 		prefs.leds_hb_mode = buf[off++];
 	}
+	/* Offset 174: led_brightness (ZephCore extension, since 1.17.4). Absent
+	 * in pre-existing files -> stays at the initNodePrefs() default of
+	 * ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT (10%), same value a fresh node
+	 * already showed before this field was persisted. Range re-checked by
+	 * sanitizeNodePrefs() below. */
+	if (off < len) {
+		prefs.led_brightness = buf[off++];
+	}
 
 	sanitizeNodePrefs(&prefs);
 }
@@ -1022,7 +1030,9 @@ void ZephyrDataStore::savePrefs(const NodePrefs &prefs)
 	/* Offset 172-173: leds_radio_mode / leds_hb_mode (ZephCore extension). */
 	buf[off++] = prefs.leds_radio_mode;
 	buf[off++] = prefs.leds_hb_mode;
-	/* Total: 174 bytes */
+	/* Offset 174: led_brightness (ZephCore extension, since 1.17.4). */
+	buf[off++] = prefs.led_brightness;
+	/* Total: 175 bytes */
 
 	bool ok = atomicReplaceFile(PREFS_FILE, buf, off);
 	LOG_DBG("savePrefs: wrote %s, ok=%d (%d bytes), name='%.16s'",

--- a/zephcore/app/RepeaterDataStore.cpp
+++ b/zephcore/app/RepeaterDataStore.cpp
@@ -301,6 +301,11 @@ bool RepeaterDataStore::loadPrefs(NodePrefs& prefs) {
      * (activity LED on transmit, heartbeat with unread indication). */
     fs_read(&file, &prefs.leds_radio_mode, sizeof(prefs.leds_radio_mode));
     fs_read(&file, &prefs.leds_hb_mode, sizeof(prefs.leds_hb_mode));
+    /* LED brightness, offset 311 (ZephCore extension, since 1.17.4). Absent
+     * in <312-byte files; leaves the initNodePrefs() default of
+     * ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT (10%), same value a fresh node
+     * already showed before this field was persisted. */
+    fs_read(&file, &prefs.led_brightness, sizeof(prefs.led_brightness));
 
     fs_close(&file);
 
@@ -467,6 +472,8 @@ bool RepeaterDataStore::savePrefs(const NodePrefs& prefs) {
     /* LED activity/heartbeat modes (offsets 309-310) */
     fs_write(&file, &prefs.leds_radio_mode, sizeof(prefs.leds_radio_mode));
     fs_write(&file, &prefs.leds_hb_mode, sizeof(prefs.leds_hb_mode));
+    /* LED brightness (offset 311, since 1.17.4) */
+    fs_write(&file, &prefs.led_brightness, sizeof(prefs.led_brightness));
 
     ret = fs_sync(&file);
     fs_close(&file);

--- a/zephcore/app/main_observer.cpp
+++ b/zephcore/app/main_observer.cpp
@@ -385,6 +385,7 @@ int main(void)
 		zephcore_leds_set_disabled(leds_off);
 		zephcore_leds_set_radio_mode(prefs->leds_radio_mode);
 		zephcore_leds_set_hb_mode(prefs->leds_hb_mode);
+		zephcore_led_set_brightness_pct(prefs->led_brightness);
 		LOG_INF("LEDs: %s (from prefs)", leds_off ? "disabled" : "enabled");
 	}
 

--- a/zephcore/boards/common/esp32s3_pwm_led.conf
+++ b/zephcore/boards/common/esp32s3_pwm_led.conf
@@ -1,0 +1,15 @@
+# Enable PWM on ESP32-S3 sysbuild targets (shared heartbeat/TX LED brightness,
+# see the heartbeat-pwm-led / lora-tx-pwm-led devicetree aliases consumed by
+# helpers/ui/ui_common.c and adapters/board/ZephyrBoard.cpp).
+#
+# Deliberately NOT in the board *_defconfig: that file is shared by every
+# sysbuild image for the board, including mcuboot, whose minimal kernel
+# config has no k_sem_give()/k_sem_take() -- CONFIG_PWM=y there links fine for
+# the app image but fails mcuboot's link with "undefined reference to
+# z_impl_k_sem_give/take" (drivers/pwm/pwm_led_esp32.c uses a semaphore).
+# EXTRA_CONF_FILE scopes this to the app ("zephcore") image only.
+#
+# Build with:
+#   -DEXTRA_CONF_FILE="boards/common/esp32s3_usb.conf;boards/common/esp32s3_pwm_led.conf"
+
+CONFIG_PWM=y

--- a/zephcore/boards/esp32/heltec_wifi_lora32_v43/heltec_wifi_lora32_v43_procpu.dts
+++ b/zephcore/boards/esp32/heltec_wifi_lora32_v43/heltec_wifi_lora32_v43_procpu.dts
@@ -47,6 +47,13 @@
 		led0 = &led0;
 		pwm-0 = &ledc0;
 		pwm-led0 = &pwm_led_white;
+		/* Single physical LED, shared between the heartbeat and LoRa TX
+		 * activity roles (same node aliased twice), same pattern as T096 and
+		 * Wireless Tracker V2 -- see helpers/ui/ui_common.c and
+		 * adapters/board/ZephyrBoard.cpp (ZEPHCORE_LED_PIN_SHARED covers the
+		 * arbitration between the two roles automatically). */
+		heartbeat-pwm-led = &pwm_led_white;
+		lora-tx-pwm-led = &pwm_led_white;
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
 		lora0 = &lora0;

--- a/zephcore/boards/esp32/heltec_wireless_tracker_v2/heltec_wireless_tracker_v2-pinctrl.dtsi
+++ b/zephcore/boards/esp32/heltec_wireless_tracker_v2/heltec_wireless_tracker_v2-pinctrl.dtsi
@@ -72,4 +72,11 @@
 			output-low;
 		};
 	};
+
+	ledc0_default: ledc0_default {
+		group1 {
+			pinmux = <LEDC_CH0_GPIO18>;
+			output-enable;
+		};
+	};
 };

--- a/zephcore/boards/esp32/heltec_wireless_tracker_v2/heltec_wireless_tracker_v2_procpu.dts
+++ b/zephcore/boards/esp32/heltec_wireless_tracker_v2/heltec_wireless_tracker_v2_procpu.dts
@@ -30,6 +30,7 @@
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/dt-bindings/lora/sx126x.h>
 #include <zephyr/dt-bindings/gpio/espressif-esp32-gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "heltec_wireless_tracker_v2-pinctrl.dtsi"
 
 / {
@@ -39,6 +40,8 @@
 	aliases {
 		led0 = &status_led;
 		lora-tx-led = &status_led;
+		heartbeat-pwm-led = &pwm_status_led;
+		lora-tx-pwm-led = &pwm_status_led;
 		uart-0 = &uart0;
 		uart-2 = &uart2;
 		i2c-0 = &i2c0;
@@ -66,6 +69,22 @@
 		status_led: led_0 {
 			gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
 			label = "Status LED";
+		};
+	};
+
+	/* Same GPIO18 net as status_led above, driven through the LEDC PWM
+	 * peripheral instead of a raw GPIO write. Single LED doubling as
+	 * heartbeat, message/shutdown flash and LoRa TX indicator (same
+	 * "Option 1" shared-brightness pattern as T096, see helpers/ui/ui_common.c
+	 * and adapters/board/ZephyrBoard.cpp: heartbeat-pwm-led/lora-tx-pwm-led
+	 * aliases give every one of those events a single 0-100 brightness knob,
+	 * RAM-only, on top of the existing persisted on/off gate. */
+	pwm_leds {
+		compatible = "pwm-leds";
+
+		pwm_status_led: pwm_led_gpio18 {
+			label = "Status PWM LED";
+			pwms = <&ledc0 0 PWM_MSEC(10) PWM_POLARITY_NORMAL>;
 		};
 	};
 
@@ -229,6 +248,19 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+&ledc0 {
+	pinctrl-0 = <&ledc0_default>;
+	pinctrl-names = "default";
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel0@0 {
+		reg = <0x0>;
+		timer = <0>;
+	};
 };
 
 &i2c0 {

--- a/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840-pinctrl.dtsi
+++ b/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840-pinctrl.dtsi
@@ -80,4 +80,20 @@
 			low-power-enable;
 		};
 	};
+
+	/* Heartbeat/TX LED, PWM path (see heltec_t096_nrf52840.dts, pwm_led_white).
+	 * Same P0.28 net as the plain gpio-leds node — free in pinctrl, no
+	 * other peripheral claims it. */
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			low-power-enable;
+		};
+	};
 };

--- a/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840.dts
+++ b/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840.dts
@@ -15,6 +15,7 @@
 #include <zephyr/dt-bindings/lora/sx126x.h>
 #include <zephyr/dt-bindings/adc/nrf-saadc.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "heltec_t096_nrf52840-pinctrl.dtsi"
 
 / {
@@ -34,6 +35,16 @@
 	aliases {
 		led0 = &led_white;
 		lora-tx-led = &led_white;
+		/* Same physical LED (P0.28) as led0/lora-tx-led above, reached
+		 * through the PWM peripheral instead of a raw GPIO write. Both
+		 * ui_common.c (heartbeat/message/shutdown) and ZephyrBoard.cpp
+		 * (LoRa TX flash) prefer this alias over the plain GPIO one when
+		 * it exists, so every event that used to hit led_white now goes
+		 * through the shared brightness in helpers/led_gate.h instead —
+		 * deliberately one dimmer for the whole LED, not a separate
+		 * heartbeat-only control (see helpers/led_gate.h). */
+		heartbeat-pwm-led = &pwm_led_white;
+		lora-tx-pwm-led = &pwm_led_white;
 		sw0 = &user_button;
 		lora0 = &lora;
 		watchdog0 = &wdt0;
@@ -48,6 +59,20 @@
 		led_white: led_0 {
 			gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
 			label = "White LED";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		/* Same P0.28 net as led_white above, driven by PWM0 channel 0
+		 * instead. Declaring both DT nodes for one pin is an established
+		 * pattern in this project (Heltec V4.3 does the same for its own
+		 * LED) — only one of the two code paths is ever compiled in for a
+		 * given purpose, selected by which alias exists. */
+		pwm_led_white: pwm_led_gpio28 {
+			label = "White PWM LED";
+			pwms = <&pwm0 0 PWM_MSEC(10) PWM_POLARITY_NORMAL>;
 		};
 	};
 
@@ -277,6 +302,14 @@
 
 &gpio1 {
 	status = "okay";
+};
+
+/* Drives the shared heartbeat/TX LED (P0.28) via pwm_led_white above. */
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &i2c0 {

--- a/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840_defconfig
+++ b/zephcore/boards/nrf52840/heltec_t096/heltec_t096_nrf52840_defconfig
@@ -10,6 +10,9 @@ CONFIG_HW_STACK_PROTECTION=y
 # Enable GPIO
 CONFIG_GPIO=y
 
+# Enable PWM (shared heartbeat/TX LED brightness)
+CONFIG_PWM=y
+
 # Enable UART driver
 CONFIG_SERIAL=y
 

--- a/zephcore/helpers/CommonCLI.cpp
+++ b/zephcore/helpers/CommonCLI.cpp
@@ -435,8 +435,11 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         } else if (memcmp(config, "leds.brightness", 15) == 0) {
             /* Separate from "leds" on purpose: keeps the on/off switch a
              * pure word command and the dimmer a pure number command,
-             * instead of one command parsing both — see led_gate.h. */
-            snprintf(reply, CLI_REPLY_SIZE, "> %u%%", (unsigned)zephcore_led_brightness_pct());
+             * instead of one command parsing both — see led_gate.h. Read
+             * from _prefs, same as leds.radio/leds.hb above, not from the
+             * RAM getter directly -- the two are always in sync, the "set"
+             * handler below writes both together. */
+            snprintf(reply, CLI_REPLY_SIZE, "> %u%%", (unsigned)_prefs->led_brightness);
         } else if (memcmp(config, "leds", 4) == 0) {
             snprintf(reply, CLI_REPLY_SIZE, "> %s", _prefs->leds_disabled ? "off" : "on");
 #ifndef ZEPHCORE_REPEATER
@@ -749,8 +752,12 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         } else if (memcmp(config, "leds.brightness ", 16) == 0) {
             /* Separate from "leds" on purpose: keeps the on/off switch a pure
              * word command and the dimmer a pure number command, instead of
-             * one command parsing both. RAM-only, see led_gate.h — no
-             * savePrefs() call here. Checked before "leds " below so this
+             * one command parsing both. Persisted (since 1.17.4): a fresh
+             * node still starts at ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT (the
+             * append-only prefs format leaves this byte at the
+             * initNodePrefs() default on any file that predates this field),
+             * but once set it survives reboots and firmware updates like
+             * leds.radio/leds.hb above. Checked before "leds " below so this
              * longer, more specific prefix is never shadowed by it. */
             const char *val = &config[16];
             char *endptr = (char *)val;
@@ -760,7 +767,9 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                 pct < 0 || pct > 100) {
                 strcpy(reply, "Error: must be 0-100");
             } else {
+                _prefs->led_brightness = (uint8_t)pct;
                 zephcore_led_set_brightness_pct((uint8_t)pct);
+                savePrefs();
                 snprintf(reply, CLI_REPLY_SIZE, "OK - leds.brightness=%ld%%", pct);
             }
         } else if (memcmp(config, "leds ", 5) == 0) {

--- a/zephcore/helpers/CommonCLI.cpp
+++ b/zephcore/helpers/CommonCLI.cpp
@@ -422,8 +422,8 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
         } else if (memcmp(config, "int.thresh", 10) == 0) {
             snprintf(reply, CLI_REPLY_SIZE, "> %u", (uint32_t)_prefs->interference_threshold);
         /* MUST stay above the "leds" branch: that one compares only the first
-         * four characters, so "leds.radio" and "leds.hb" both match it and
-         * would otherwise return the master switch instead. */
+         * four characters, so "leds.radio"/"leds.hb"/"leds.brightness" all
+         * match it and would otherwise return the master switch instead. */
         } else if (memcmp(config, "leds.radio", 10) == 0) {
             snprintf(reply, CLI_REPLY_SIZE, "> %s%s",
                      cliModeName(LEDS_RADIO_NAMES, 4, _prefs->leds_radio_mode),
@@ -432,17 +432,13 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
             snprintf(reply, CLI_REPLY_SIZE, "> %s%s",
                      cliModeName(LEDS_HB_NAMES, 4, _prefs->leds_hb_mode),
                      CLI_HAS_HB_LED ? "" : " (no heartbeat LED on this board)");
+        } else if (memcmp(config, "leds.brightness", 15) == 0) {
+            /* Separate from "leds" on purpose: keeps the on/off switch a
+             * pure word command and the dimmer a pure number command,
+             * instead of one command parsing both — see led_gate.h. */
+            snprintf(reply, CLI_REPLY_SIZE, "> %u%%", (unsigned)zephcore_led_brightness_pct());
         } else if (memcmp(config, "leds", 4) == 0) {
-            /* Brightness (RAM-only, see led_gate.h) reported alongside the
-             * persisted on/off gate, same "state N%" convention as led.tx/
-             * led.hb on the RAK3401 branch. */
-            if (_prefs->leds_disabled) {
-                snprintf(reply, CLI_REPLY_SIZE, "> off (%u%%)",
-                         (unsigned)zephcore_led_brightness_pct());
-            } else {
-                snprintf(reply, CLI_REPLY_SIZE, "> on %u%%",
-                         (unsigned)zephcore_led_brightness_pct());
-            }
+            snprintf(reply, CLI_REPLY_SIZE, "> %s", _prefs->leds_disabled ? "off" : "on");
 #ifndef ZEPHCORE_REPEATER
         } else if (memcmp(config, "buzzer", 6) == 0) {
             uint8_t mode = zephcore_buzzer_mode_from_prefs(_prefs->buzzer_quiet);
@@ -750,18 +746,33 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                 snprintf(reply, CLI_REPLY_SIZE, "OK%s",
                          CLI_HAS_HB_LED ? "" : " (no heartbeat LED on this board)");
             }
+        } else if (memcmp(config, "leds.brightness ", 16) == 0) {
+            /* Separate from "leds" on purpose: keeps the on/off switch a pure
+             * word command and the dimmer a pure number command, instead of
+             * one command parsing both. RAM-only, see led_gate.h — no
+             * savePrefs() call here. Checked before "leds " below so this
+             * longer, more specific prefix is never shadowed by it. */
+            const char *val = &config[16];
+            char *endptr = (char *)val;
+            long pct = strtol(val, &endptr, 10);
+            bool trailing_pct = (*endptr == '%' && *(endptr + 1) == '\0');
+            if (endptr == val || (*endptr != '\0' && !trailing_pct) ||
+                pct < 0 || pct > 100) {
+                strcpy(reply, "Error: must be 0-100");
+            } else {
+                zephcore_led_set_brightness_pct((uint8_t)pct);
+                snprintf(reply, CLI_REPLY_SIZE, "OK - leds.brightness=%ld%%", pct);
+            }
         } else if (memcmp(config, "leds ", 5) == 0) {
             /* Master switch (persisted) for every LED on the node: heartbeat,
              * unread-message and LoRa TX activity, plus the message and
              * shutdown flashes. Not the display backlight — that has its own
-             * UI brightness setting.
-             *
-             * Same value orthogonal to a shared brightness (RAM-only, see
-             * led_gate.h) as led.tx/led.hb on the RAK3401 branch: "on"/"off"
-             * words only, no "1"/"0" aliases (those would shadow the 1% and
-             * 0% brightness values — the exact ambiguity already found and
-             * removed from led.tx/led.hb on 2026-08-16). A bare 0-100 number
-             * sets the brightness alone and never touches the switch. */
+             * UI brightness setting. "on"/"off" words only, no "1"/"0"
+             * aliases (removed from led.tx/led.hb on 2026-08-16 for the same
+             * reason: they used to collide with the 1% and 0% brightness
+             * values on that branch — moot here since brightness now lives
+             * under "leds.brightness" instead, but kept out anyway for
+             * consistency and to reject typos cleanly). */
             const char* val = &config[5];
             if (memcmp(val, "on", 2) == 0 && val[2] == '\0') {
                 _prefs->leds_disabled = 0;
@@ -774,16 +785,7 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                 savePrefs();
                 strcpy(reply, "OK");
             } else {
-                char *endptr = (char *)val;
-                long pct = strtol(val, &endptr, 10);
-                bool trailing_pct = (*endptr == '%' && *(endptr + 1) == '\0');
-                if (endptr == val || (*endptr != '\0' && !trailing_pct) ||
-                    pct < 0 || pct > 100) {
-                    strcpy(reply, "Error: must be on, off, or 0-100");
-                } else {
-                    zephcore_led_set_brightness_pct((uint8_t)pct);
-                    snprintf(reply, CLI_REPLY_SIZE, "OK - leds=%ld%%", pct);
-                }
+                strcpy(reply, "Error: must be on or off");
             }
 #ifndef ZEPHCORE_REPEATER
         } else if (memcmp(config, "buzzer ", 7) == 0) {

--- a/zephcore/helpers/CommonCLI.cpp
+++ b/zephcore/helpers/CommonCLI.cpp
@@ -433,12 +433,16 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                      cliModeName(LEDS_HB_NAMES, 4, _prefs->leds_hb_mode),
                      CLI_HAS_HB_LED ? "" : " (no heartbeat LED on this board)");
         } else if (memcmp(config, "leds", 4) == 0) {
-            snprintf(reply, CLI_REPLY_SIZE, "> %s", _prefs->leds_disabled ? "off" : "on");
-        } else if (memcmp(config, "led", 3) == 0) {
-            /* Shared heartbeat/TX brightness, RAM-only — see led_gate.h.
-             * Checked after "leds" above so "leds" itself never falls
-             * through to this shorter prefix. */
-            snprintf(reply, CLI_REPLY_SIZE, "> %u%%", (unsigned)zephcore_led_brightness_pct());
+            /* Brightness (RAM-only, see led_gate.h) reported alongside the
+             * persisted on/off gate, same "state N%" convention as led.tx/
+             * led.hb on the RAK3401 branch. */
+            if (_prefs->leds_disabled) {
+                snprintf(reply, CLI_REPLY_SIZE, "> off (%u%%)",
+                         (unsigned)zephcore_led_brightness_pct());
+            } else {
+                snprintf(reply, CLI_REPLY_SIZE, "> on %u%%",
+                         (unsigned)zephcore_led_brightness_pct());
+            }
 #ifndef ZEPHCORE_REPEATER
         } else if (memcmp(config, "buzzer", 6) == 0) {
             uint8_t mode = zephcore_buzzer_mode_from_prefs(_prefs->buzzer_quiet);
@@ -747,28 +751,39 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                          CLI_HAS_HB_LED ? "" : " (no heartbeat LED on this board)");
             }
         } else if (memcmp(config, "leds ", 5) == 0) {
-            /* Master switch for every LED on the node: heartbeat, unread-message
-             * and LoRa TX activity, plus the message and shutdown flashes. Not
-             * the display backlight — that has its own UI brightness setting. */
-            int on = cliOnOff(&config[5], cliDefaults()->leds_disabled ? 0 : 1);
-            if (on < 0) {
-                strcpy(reply, "Error: must be on, off or default");
-            } else {
-                _prefs->leds_disabled = on ? 0 : 1;
-                zephcore_leds_set_disabled(_prefs->leds_disabled != 0);
+            /* Master switch (persisted) for every LED on the node: heartbeat,
+             * unread-message and LoRa TX activity, plus the message and
+             * shutdown flashes. Not the display backlight — that has its own
+             * UI brightness setting.
+             *
+             * Same value orthogonal to a shared brightness (RAM-only, see
+             * led_gate.h) as led.tx/led.hb on the RAK3401 branch: "on"/"off"
+             * words only, no "1"/"0" aliases (those would shadow the 1% and
+             * 0% brightness values — the exact ambiguity already found and
+             * removed from led.tx/led.hb on 2026-08-16). A bare 0-100 number
+             * sets the brightness alone and never touches the switch. */
+            const char* val = &config[5];
+            if (memcmp(val, "on", 2) == 0 && val[2] == '\0') {
+                _prefs->leds_disabled = 0;
+                zephcore_leds_set_disabled(false);
                 savePrefs();
                 strcpy(reply, "OK");
-            }
-        } else if (memcmp(config, "led ", 4) == 0) {
-            /* Brightness only, on/off stays on "set leds" above. RAM-only —
-             * no savePrefs() call here on purpose, see led_gate.h. Checked
-             * after "leds " so that command never falls through here. */
-            int pct = atoi(&config[4]);
-            if (pct < 0 || pct > 100) {
-                strcpy(reply, "Error: must be 0-100");
+            } else if (memcmp(val, "off", 3) == 0 && val[3] == '\0') {
+                _prefs->leds_disabled = 1;
+                zephcore_leds_set_disabled(true);
+                savePrefs();
+                strcpy(reply, "OK");
             } else {
-                zephcore_led_set_brightness_pct((uint8_t)pct);
-                snprintf(reply, CLI_REPLY_SIZE, "OK - led=%d%%", pct);
+                char *endptr = (char *)val;
+                long pct = strtol(val, &endptr, 10);
+                bool trailing_pct = (*endptr == '%' && *(endptr + 1) == '\0');
+                if (endptr == val || (*endptr != '\0' && !trailing_pct) ||
+                    pct < 0 || pct > 100) {
+                    strcpy(reply, "Error: must be on, off, or 0-100");
+                } else {
+                    zephcore_led_set_brightness_pct((uint8_t)pct);
+                    snprintf(reply, CLI_REPLY_SIZE, "OK - leds=%ld%%", pct);
+                }
             }
 #ifndef ZEPHCORE_REPEATER
         } else if (memcmp(config, "buzzer ", 7) == 0) {

--- a/zephcore/helpers/CommonCLI.cpp
+++ b/zephcore/helpers/CommonCLI.cpp
@@ -434,6 +434,11 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                      CLI_HAS_HB_LED ? "" : " (no heartbeat LED on this board)");
         } else if (memcmp(config, "leds", 4) == 0) {
             snprintf(reply, CLI_REPLY_SIZE, "> %s", _prefs->leds_disabled ? "off" : "on");
+        } else if (memcmp(config, "led", 3) == 0) {
+            /* Shared heartbeat/TX brightness, RAM-only — see led_gate.h.
+             * Checked after "leds" above so "leds" itself never falls
+             * through to this shorter prefix. */
+            snprintf(reply, CLI_REPLY_SIZE, "> %u%%", (unsigned)zephcore_led_brightness_pct());
 #ifndef ZEPHCORE_REPEATER
         } else if (memcmp(config, "buzzer", 6) == 0) {
             uint8_t mode = zephcore_buzzer_mode_from_prefs(_prefs->buzzer_quiet);
@@ -753,6 +758,17 @@ void CommonCLI::handleCommand(uint32_t sender_timestamp, const char* command, ch
                 zephcore_leds_set_disabled(_prefs->leds_disabled != 0);
                 savePrefs();
                 strcpy(reply, "OK");
+            }
+        } else if (memcmp(config, "led ", 4) == 0) {
+            /* Brightness only, on/off stays on "set leds" above. RAM-only —
+             * no savePrefs() call here on purpose, see led_gate.h. Checked
+             * after "leds " so that command never falls through here. */
+            int pct = atoi(&config[4]);
+            if (pct < 0 || pct > 100) {
+                strcpy(reply, "Error: must be 0-100");
+            } else {
+                zephcore_led_set_brightness_pct((uint8_t)pct);
+                snprintf(reply, CLI_REPLY_SIZE, "OK - led=%d%%", pct);
             }
 #ifndef ZEPHCORE_REPEATER
         } else if (memcmp(config, "buzzer ", 7) == 0) {

--- a/zephcore/helpers/NodePrefs.h
+++ b/zephcore/helpers/NodePrefs.h
@@ -95,6 +95,7 @@ struct NodePrefs {
 	uint8_t leds_disabled;          // 1 = all LEDs off (heartbeat, unread, LoRa TX)
 	uint8_t leds_radio_mode;        // LEDS_RADIO_* — activity LED source (0 = TX, as before)
 	uint8_t leds_hb_mode;           // LEDS_HB_* — heartbeat LED behaviour (0 = all, as before)
+	uint8_t led_brightness;         // 0-100, PWM-capable boards only; ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT on a new node
 	// Power saving
 	uint8_t powersaving_enabled;
 	// GPS settings
@@ -284,6 +285,7 @@ static inline void sanitizeNodePrefs(NodePrefs* p) {
 	p->leds_disabled       = saneBool<uint8_t>(p->leds_disabled, 0);
 	p->leds_radio_mode     = saneEnum(p->leds_radio_mode, LEDS_RADIO_MAX);
 	p->leds_hb_mode        = saneEnum(p->leds_hb_mode, LEDS_HB_MAX);
+	p->led_brightness      = clampPref<uint8_t>(p->led_brightness, 0, 100);
 	p->meshtimesync        = saneBool<uint8_t>(p->meshtimesync, 0);
 	/* Fallback must be the initNodePrefs() default (ON).  It was 0, so a byte
 	 * that was neither 0 nor 1 silently switched adaptive CAD off instead of
@@ -386,6 +388,7 @@ static inline void initNodePrefs(NodePrefs* prefs) {
 	prefs->leds_disabled = 0;         // LEDs on
 	prefs->leds_radio_mode = LEDS_RADIO_TX;  // activity LED on transmit, as before
 	prefs->leds_hb_mode = LEDS_HB_ALL;       // heartbeat + unread, as before
+	prefs->led_brightness = ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT;  // 10%, new node
 	prefs->powersaving_enabled = 0;
 	prefs->gps_enabled = 0;
 	prefs->gps_interval = 300;        // 5 minutes

--- a/zephcore/helpers/NodePrefs.h
+++ b/zephcore/helpers/NodePrefs.h
@@ -388,7 +388,7 @@ static inline void initNodePrefs(NodePrefs* prefs) {
 	prefs->leds_disabled = 0;         // LEDs on
 	prefs->leds_radio_mode = LEDS_RADIO_TX;  // activity LED on transmit, as before
 	prefs->leds_hb_mode = LEDS_HB_ALL;       // heartbeat + unread, as before
-	prefs->led_brightness = ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT;  // 10%, new node
+	prefs->led_brightness = ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT;  // 100%, new node
 	prefs->powersaving_enabled = 0;
 	prefs->gps_enabled = 0;
 	prefs->gps_interval = 300;        // 5 minutes

--- a/zephcore/helpers/led_gate.c
+++ b/zephcore/helpers/led_gate.c
@@ -74,3 +74,21 @@ void zephcore_led_radio_hold_pin(bool held)
 {
 	atomic_set(&s_radio_holds_pin, held ? 1 : 0);
 }
+
+/* Same cross-thread readers/writers as the gate above (heartbeat work queue,
+ * TX path, CLI) — atomic for the same reason. RAM-only on purpose: no
+ * savePrefs() call anywhere near this, see led_gate.h. */
+static atomic_t s_led_brightness_pct = ATOMIC_INIT(ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT);
+
+uint8_t zephcore_led_brightness_pct(void)
+{
+	return (uint8_t)atomic_get(&s_led_brightness_pct);
+}
+
+void zephcore_led_set_brightness_pct(uint8_t pct)
+{
+	if (pct > 100) {
+		pct = 100;
+	}
+	atomic_set(&s_led_brightness_pct, pct);
+}

--- a/zephcore/helpers/led_gate.h
+++ b/zephcore/helpers/led_gate.h
@@ -36,13 +36,13 @@ void zephcore_leds_set_disabled(bool disabled);
 
 /* Shared PWM brightness (0-100) for boards whose heartbeat/TX LED is
  * PWM-capable (DT_ALIAS(heartbeat_pwm_led) / DT_ALIAS(lora_tx_pwm_led)).
- * Deliberately RAM-only, not persisted: resets to
- * ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT on every reboot regardless of any
- * "set led <pct>" done during a previous session. Independent of the on/off
- * gate above: brightness only matters while the gate is open. No-op on
- * boards without a PWM-capable LED (the getter still returns the compiled
- * default, simply unused). */
-#define ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT 10
+ * Persisted via NodePrefs (prefs.led_brightness); ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT
+ * only seeds the RAM cache on a fresh node with no saved value yet (100%,
+ * matching the brightness every PWM LED ran at before this setting existed).
+ * Independent of the on/off gate above: brightness only matters while the
+ * gate is open. No-op on boards without a PWM-capable LED (the getter still
+ * returns the compiled default, simply unused). */
+#define ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT 100
 
 uint8_t zephcore_led_brightness_pct(void);
 void zephcore_led_set_brightness_pct(uint8_t pct);

--- a/zephcore/helpers/led_gate.h
+++ b/zephcore/helpers/led_gate.h
@@ -34,6 +34,19 @@ bool zephcore_leds_disabled(void);
  * progress. Safe to call from any role, with or without a UI. */
 void zephcore_leds_set_disabled(bool disabled);
 
+/* Shared PWM brightness (0-100) for boards whose heartbeat/TX LED is
+ * PWM-capable (DT_ALIAS(heartbeat_pwm_led) / DT_ALIAS(lora_tx_pwm_led)).
+ * Deliberately RAM-only, not persisted: resets to
+ * ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT on every reboot regardless of any
+ * "set led <pct>" done during a previous session. Independent of the on/off
+ * gate above: brightness only matters while the gate is open. No-op on
+ * boards without a PWM-capable LED (the getter still returns the compiled
+ * default, simply unused). */
+#define ZEPHCORE_LED_DEFAULT_BRIGHTNESS_PCT 10
+
+uint8_t zephcore_led_brightness_pct(void);
+void zephcore_led_set_brightness_pct(uint8_t pct);
+
 /* Called by zephcore_leds_set_disabled() after the flag changes. Weak no-op in
  * led_gate.c; helpers/ui/ui_common.c overrides it to stop/restart the heartbeat
  * cycle and refresh the UI's LED page. Not meant to be called directly. */

--- a/zephcore/helpers/ui/ui_common.c
+++ b/zephcore/helpers/ui/ui_common.c
@@ -22,6 +22,7 @@
 #include "led_gate.h"               /* shared with the LoRa TX LED */
 
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
 #include <zephyr/dt-bindings/input/input-event-codes.h>
 #include <zephyr/kernel.h>
 #include <string.h>
@@ -95,21 +96,63 @@ void ui_play_startup_chime(void)
  * only when msg count > 0, giving a visual unread-message reminder.
  */
 
-#if DT_NODE_HAS_PROP(DT_ALIAS(led0), gpios)
+/* PWM path (brightness-capable, shared with the LoRa TX LED via the same
+ * DT_ALIAS(heartbeat_pwm_led)/DT_ALIAS(lora_tx_pwm_led) pair when a board's
+ * heartbeat and TX indicator are the same physical LED, e.g. T096) takes
+ * priority over the plain digital led0/led1 fallback. Brightness comes from
+ * helpers/led_gate.h — one dimmer for every event on this LED, not a
+ * heartbeat-only one. */
+#if DT_NODE_EXISTS(DT_ALIAS(heartbeat_pwm_led))
+static const struct pwm_dt_spec s_heartbeat_led_pwm =
+	PWM_DT_SPEC_GET(DT_ALIAS(heartbeat_pwm_led));
+#define HAS_HEARTBEAT_LED_PWM 1
+#define HAS_HEARTBEAT_LED 0
+#elif DT_NODE_HAS_PROP(DT_ALIAS(led0), gpios)
 static const struct gpio_dt_spec s_heartbeat_led =
 	GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
+#define HAS_HEARTBEAT_LED_PWM 0
 #define HAS_HEARTBEAT_LED 1
 #elif DT_NODE_HAS_PROP(DT_ALIAS(led1), gpios)
 static const struct gpio_dt_spec s_heartbeat_led =
 	GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);
+#define HAS_HEARTBEAT_LED_PWM 0
 #define HAS_HEARTBEAT_LED 1
 #else
+#define HAS_HEARTBEAT_LED_PWM 0
 #define HAS_HEARTBEAT_LED 0
+#endif
+
+/* "Some heartbeat LED exists, PWM or plain GPIO" — used where the on/off
+ * write differs but everything else (work queue plumbing, readiness check)
+ * is identical either way. */
+#define HAS_ANY_HEARTBEAT_LED (HAS_HEARTBEAT_LED_PWM || HAS_HEARTBEAT_LED)
+
+#if HAS_HEARTBEAT_LED_PWM
+static inline bool heartbeat_led_is_ready(void)
+{
+	return pwm_is_ready_dt(&s_heartbeat_led_pwm);
+}
+static inline void heartbeat_led_write(bool on)
+{
+	uint32_t pulse = on ? (uint32_t)((uint64_t)s_heartbeat_led_pwm.period *
+					  zephcore_led_brightness_pct() / 100)
+			     : 0;
+	pwm_set_pulse_dt(&s_heartbeat_led_pwm, pulse);
+}
+#elif HAS_HEARTBEAT_LED
+static inline bool heartbeat_led_is_ready(void)
+{
+	return gpio_is_ready_dt(&s_heartbeat_led);
+}
+static inline void heartbeat_led_write(bool on)
+{
+	gpio_pin_set_dt(&s_heartbeat_led, on ? 1 : 0);
+}
 #endif
 
 /* Second LED for unread-message indication. Repeaters use led1 for LoRa TX
  * (via lora-tx-led alias) — no offline queue, so this is companion-only. */
-#if HAS_HEARTBEAT_LED && DT_NODE_HAS_PROP(DT_ALIAS(led0), gpios) && \
+#if HAS_ANY_HEARTBEAT_LED && DT_NODE_HAS_PROP(DT_ALIAS(led0), gpios) && \
     DT_NODE_HAS_PROP(DT_ALIAS(led1), gpios) && !defined(ZEPHCORE_REPEATER)
 static const struct gpio_dt_spec s_msg_led =
 	GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);
@@ -122,7 +165,7 @@ static const struct gpio_dt_spec s_msg_led =
 #define LED_ON_MS         20   /* Normal pulse width */
 #define LED_ON_MSG_MS    200   /* Pulse width when unread messages */
 
-#if HAS_HEARTBEAT_LED
+#if HAS_ANY_HEARTBEAT_LED
 static struct k_work_delayable s_led_on_work;
 static struct k_work_delayable s_led_off_work;
 
@@ -167,9 +210,11 @@ static void led_off_work_handler(struct k_work *work)
 	ARG_UNUSED(work);
 	/* Yield the pin if radio activity is holding it (shared-pin boards only;
 	 * everywhere else this always reads false). Clearing here would blank the
-	 * LED in the middle of a transmit. */
+	 * LED in the middle of a transmit. Routed through heartbeat_led_write()
+	 * rather than a direct gpio_pin_set_dt(), since s_heartbeat_led doesn't
+	 * even exist on PWM-capable boards (see HAS_HEARTBEAT_LED_PWM above). */
 	if (!zephcore_led_radio_holds_pin()) {
-		gpio_pin_set_dt(&s_heartbeat_led, 0);
+		heartbeat_led_write(false);
 	}
 #if HAS_MSG_LED
 	gpio_pin_set_dt(&s_msg_led, 0);
@@ -187,7 +232,7 @@ static void led_on_work_handler(struct k_work *work)
 
 	if (!zephcore_leds_disabled()) {
 		if (hb_should_light(mc) && !zephcore_led_radio_holds_pin()) {
-			gpio_pin_set_dt(&s_heartbeat_led, 1);
+			heartbeat_led_write(true);
 		}
 #if HAS_MSG_LED
 		/* The unread LED is a separate pin, so it is governed by the mode
@@ -201,7 +246,7 @@ static void led_on_work_handler(struct k_work *work)
 	}
 	k_work_reschedule(&s_led_off_work, K_MSEC(on_ms));
 }
-#endif /* HAS_HEARTBEAT_LED */
+#endif /* HAS_ANY_HEARTBEAT_LED */
 
 /*
  * Weak: called after s_leds_disabled changes so each UI variant can sync its
@@ -212,9 +257,13 @@ __attribute__((weak)) void ui_led_on_disabled_changed(bool disabled) { ARG_UNUSE
 
 void ui_led_heartbeat_init(void)
 {
+#if HAS_ANY_HEARTBEAT_LED
+	if (heartbeat_led_is_ready()) {
 #if HAS_HEARTBEAT_LED
-	if (gpio_is_ready_dt(&s_heartbeat_led)) {
 		gpio_pin_configure_dt(&s_heartbeat_led, GPIO_OUTPUT_INACTIVE);
+#else
+		heartbeat_led_write(false);
+#endif
 		k_work_init_delayable(&s_led_on_work, led_on_work_handler);
 		k_work_init_delayable(&s_led_off_work, led_off_work_handler);
 		k_work_reschedule(&s_led_on_work, K_NO_WAIT);
@@ -231,15 +280,15 @@ void ui_led_heartbeat_init(void)
 
 void ui_set_heartbeat_led(bool enabled)
 {
-#if HAS_HEARTBEAT_LED
+#if HAS_ANY_HEARTBEAT_LED
 	if (enabled && !zephcore_leds_disabled()) {
-		if (gpio_is_ready_dt(&s_heartbeat_led)) {
+		if (heartbeat_led_is_ready()) {
 			k_work_reschedule(&s_led_on_work, K_NO_WAIT);
 		}
 	} else {
 		k_work_cancel_delayable(&s_led_on_work);
 		k_work_cancel_delayable(&s_led_off_work);
-		gpio_pin_set_dt(&s_heartbeat_led, 0);
+		heartbeat_led_write(false);
 #if HAS_MSG_LED
 		gpio_pin_set_dt(&s_msg_led, 0);
 #endif
@@ -257,18 +306,18 @@ void ui_set_heartbeat_led(bool enabled)
  */
 void zephcore_leds_ui_sync(bool disabled)
 {
-#if HAS_HEARTBEAT_LED
+#if HAS_ANY_HEARTBEAT_LED
 	if (disabled) {
 		k_work_cancel_delayable(&s_led_on_work);
 		k_work_cancel_delayable(&s_led_off_work);
-		gpio_pin_set_dt(&s_heartbeat_led, 0);
+		heartbeat_led_write(false);
 #if HAS_MSG_LED
 		gpio_pin_set_dt(&s_msg_led, 0);
 #endif
 	} else if (!k_work_delayable_is_pending(&s_led_on_work) &&
 		   !k_work_delayable_is_pending(&s_led_off_work)) {
 		/* Restart heartbeat only if it was stopped (avoids spurious pulse) */
-		if (gpio_is_ready_dt(&s_heartbeat_led)) {
+		if (heartbeat_led_is_ready()) {
 			k_work_reschedule(&s_led_on_work, K_NO_WAIT);
 		}
 	}
@@ -292,11 +341,11 @@ void ui_set_leds_disabled(bool disabled)
  * No-op when LEDs are disabled or hardware is absent. */
 void ui_led_flash_msg(void)
 {
-#if HAS_HEARTBEAT_LED
-	if (!zephcore_leds_disabled() && gpio_is_ready_dt(&s_heartbeat_led)) {
+#if HAS_ANY_HEARTBEAT_LED
+	if (!zephcore_leds_disabled() && heartbeat_led_is_ready()) {
 		k_work_cancel_delayable(&s_led_on_work);
 		k_work_cancel_delayable(&s_led_off_work);
-		gpio_pin_set_dt(&s_heartbeat_led, 1);
+		heartbeat_led_write(true);
 		k_work_reschedule(&s_led_off_work, K_MSEC(LED_ON_MSG_MS));
 	}
 #endif
@@ -308,12 +357,12 @@ void ui_led_flash_msg(void)
  * even at power-off. */
 void ui_led_flash_shutdown(void)
 {
-#if HAS_HEARTBEAT_LED
-	if (!zephcore_leds_disabled() && gpio_is_ready_dt(&s_heartbeat_led)) {
+#if HAS_ANY_HEARTBEAT_LED
+	if (!zephcore_leds_disabled() && heartbeat_led_is_ready()) {
 		for (int i = 0; i < 3; i++) {
-			gpio_pin_set_dt(&s_heartbeat_led, 1);
+			heartbeat_led_write(true);
 			k_sleep(K_MSEC(100));
-			gpio_pin_set_dt(&s_heartbeat_led, 0);
+			heartbeat_led_write(false);
 			if (i < 2) {
 				k_sleep(K_MSEC(100));
 			}

--- a/zephcore/src/main_companion.cpp
+++ b/zephcore/src/main_companion.cpp
@@ -1603,6 +1603,7 @@ int main(void)
 	zephcore_leds_set_disabled(leds_off);
 	zephcore_leds_set_radio_mode(companion_mesh.prefs.leds_radio_mode);
 	zephcore_leds_set_hb_mode(companion_mesh.prefs.leds_hb_mode);
+	zephcore_led_set_brightness_pct(companion_mesh.prefs.led_brightness);
 	ui_set_heartbeat_led(!leds_off);
 	LOG_INF("LEDs: %s (from prefs)", leds_off ? "disabled" : "enabled");
 

--- a/zephcore/src/main_repeater.cpp
+++ b/zephcore/src/main_repeater.cpp
@@ -775,6 +775,7 @@ int main(void)
 		zephcore_leds_set_disabled(leds_off);
 		zephcore_leds_set_radio_mode(lp->leds_radio_mode);
 		zephcore_leds_set_hb_mode(lp->leds_hb_mode);
+		zephcore_led_set_brightness_pct(lp->led_brightness);
 		LOG_INF("LEDs: %s (from prefs)", leds_off ? "disabled" : "enabled");
 	}
 

--- a/zephcore/src/main_room_server.cpp
+++ b/zephcore/src/main_room_server.cpp
@@ -660,6 +660,7 @@ int main(void)
 		zephcore_leds_set_disabled(leds_off);
 		zephcore_leds_set_radio_mode(lp->leds_radio_mode);
 		zephcore_leds_set_hb_mode(lp->leds_hb_mode);
+		zephcore_led_set_brightness_pct(lp->led_brightness);
 		LOG_INF("LEDs: %s (from prefs)", leds_off ? "disabled" : "enabled");
 	}
 


### PR DESCRIPTION
## What

Three related fixes/features for the PWM-capable heartbeat/TX LED (T096,
Wireless Tracker V2, RAK3401, and now V4.3), bundled together because the
later commits depend on the earlier ones:

1. **`set/get leds.brightness <0-100>`** for PWM-capable boards (already
   present locally for T096 and Wireless Tracker V2; this PR also wires
   V4.3's existing-but-unused PWM LED node into the same mechanism, giving
   it `leds.radio`/`leds.hb`/`leds.brightness` for the first time -- it had
   none of the three before).
2. **Brightness now persists** across reboots and firmware updates (was
   RAM-only, silently reset to the compiled default every boot).
3. **TX/RX LED pin-share arbitration extended to PWM boards.** The existing
   interlock (prevents a transmit and a heartbeat tick from clipping each
   other on a shared pin) was gated by `HAS_TX_LED` alone, so it never
   compiled in for `HAS_TX_LED_PWM` boards. Two real gaps fixed:
   - T096 and Wireless Tracker V2 alias heartbeat and TX activity to the
     *same* physical PWM LED -- exactly `ZEPHCORE_LED_PIN_SHARED`'s
     intended case -- but had no arbitration at all.
   - Every PWM board, RAK3401 included, had no RX-pulse blink: `set
     leds.radio rx` (or `all`) silently did nothing on the activity LED,
     since that whole code path only existed under plain `HAS_TX_LED`.

Default brightness is 100% (matches what every PWM LED already ran at
before this setting existed).

## Testing

Compiled clean on `heltec_t096/nrf52840`, `heltec_wireless_tracker_v2/esp32s3`,
`heltec_wifi_lora32_v43/esp32s3`, and `rak3401_1watt/nrf52840` (companion
role; RAK3401 confirms `ZEPHCORE_LED_PIN_SHARED` correctly stays 0 there,
since its two PWM LEDs are on distinct pins).

Flashed and tested on real hardware: T096 (persistence survives reboot,
heartbeat/TX arbitration confirmed visually) and V4.3 (new PWM wiring,
`leds.radio`/`leds.hb`/`leds.brightness` all functional for the first time
on this board).

## Not included

An on-screen settings menu for brightness (button-UI boards) exists on top
of this locally and works well, but it's a separate, more opinionated UI/UX
change -- happy to open it as a follow-up PR if there's interest, once this
one settles.