### PR TITLE
board: fix double-press confirm window on WT2 and V4.3

### DIFF
--- a/zephcore/boards/esp32/heltec_wifi_lora32_v43/board.conf
+++ b/zephcore/boards/esp32/heltec_wifi_lora32_v43/board.conf
@@ -23,3 +23,8 @@ CONFIG_ZEPHCORE_SX126X_HELTEC_REG_PATCH=y
 # Measured (MeshCore issue #1708, GC1109 data — KCT8103L similar): TX=18 → ~27 dBm
 # radiated, practical efficiency peak. TX=10 → ~20 dBm; TX=22 saturates same as TX=18.
 CONFIG_ZEPHCORE_DEFAULT_TX_POWER_DBM=12
+
+# Single button, ENTER emitted via a zephyr,input-longpress filter (see
+# board.overlay): the default 500ms double-press confirm window (shutdown/
+# DFU/offgrid) is too short for two ~1s holds, see Kconfig help text.
+CONFIG_ZEPHCORE_UI_CONFIRM_WINDOW_MS=3000

--- a/zephcore/boards/esp32/heltec_wireless_tracker_v2/board.conf
+++ b/zephcore/boards/esp32/heltec_wireless_tracker_v2/board.conf
@@ -23,3 +23,8 @@ CONFIG_ZEPHCORE_SX126X_HELTEC_REG_PATCH=y
 # the PA enabled. The module is physically capable of higher output; start
 # conservative to avoid overdriving the front end.
 CONFIG_ZEPHCORE_DEFAULT_TX_POWER_DBM=9
+
+# Single button, ENTER emitted via a zephyr,input-longpress filter (see
+# board.overlay): the default 500ms double-press confirm window (shutdown/
+# DFU/offgrid) is too short for two ~1s holds, see Kconfig help text.
+CONFIG_ZEPHCORE_UI_CONFIRM_WINDOW_MS=3000


### PR DESCRIPTION
## What

Wireless Tracker V2 and V4.3 both emit `ENTER` via a `zephyr,input-longpress`
filter (single button, no joystick), same category the Kconfig help text for
`CONFIG_ZEPHCORE_UI_CONFIRM_WINDOW_MS` already documents as needing 3000ms
instead of the 500ms default: two ~1s holds don't fit in a 500ms window, so
the second long press on the shutdown/DFU/offgrid confirmation pages always
arrives after the window has closed and just re-arms instead of confirming.

T096 already has this set (`board.conf`), matching T-Echo, RAK4631, T114 and
T-Impulse+. WT2 and V4.3 didn't -- apparently missed when their `board.conf`
was written, not a deliberate choice. This adds the same one-line override
to both.

## Testing

Compiled clean on `heltec_wireless_tracker_v2/esp32s3/procpu` and
`heltec_wifi_lora32_v43/esp32s3/procpu`.

Diagnosed by reading the input-longpress filter timing against the Kconfig's
own documented threshold; not yet re-verified by physically holding the
button twice on the shutdown/DFU/offgrid pages on real hardware.